### PR TITLE
Do not run integration tests as part of gradle build task.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - chmod +x gradle/wrapper/gradle-wrapper.jar
 
 script:
-  - ./gradlew clean build -i --stacktrace
+  - ./gradlew clean integrationTest build -i --stacktrace
 
 after_success:
   - ./gradlew jacocoTestReport coveralls

--- a/build-scripts/integration-tests.gradle
+++ b/build-scripts/integration-tests.gradle
@@ -23,5 +23,4 @@ task integrationTest(type: Test, dependsOn: jar) {
     outputs.upToDateWhen { false }
 }
 
-project.tasks.findByName('check').dependsOn('integrationTest')
 project.tasks.findByName('integrationTest').mustRunAfter('test')


### PR DESCRIPTION
As we are building and publishing artifacts with jitpack we need to remove the
integration-test-task dependency from the build-task because jitpack is not able to
execute the integration tests. We will call the integrationTest task explicit during
the travis build.