### PR TITLE
More specific logging of exceptions

### DIFF
--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisRecordProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisRecordProcessor.kt
@@ -47,15 +47,18 @@ class AwsKinesisRecordProcessor(
                     processRecord(recordData)
                     processedSuccessfully = true
                     break
-                } catch (t: Throwable) {
-                    log.warn("Caught throwable while processing record [{}]", record, t)
+                } catch (e: Exception) {
+                    log.error(
+                        "Exception while processing record. [sequenceNumber=${record.sequenceNumber}, partitionKey=${record.partitionKey}]",
+                        e
+                    )
                 }
 
                 backoff()
             }
 
             if (!processedSuccessfully) {
-                log.error("Couldn't process record $record. Skipping it.")
+                log.warn("Processing of record failed. Skipping it. [sequenceNumber=${record.sequenceNumber}, partitionKey=${record.partitionKey}, attempts=$maxAttempts")
             }
         }
     }


### PR DESCRIPTION
I tried to improve the logging in case of an error.

The old/current logging looks like this:

![screen shot 2018-06-29 at 14 36 47](https://user-images.githubusercontent.com/5120537/42092642-df5ea4ae-7ba9-11e8-88f8-76c9e8d5ee6b.png)

A lot of fields (such as `data`) are not readable. I think logging the sequence number and partition key should be enough.

I also switched the log level. The actual exception is the "error", skipping is just a warning.