### PR TITLE
add Record Validation before sending data to Kinesis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,9 +79,9 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-sts:${versions.awsSdk}"
     compile "com.amazonaws:amazon-kinesis-client:${versions.kinesis}"
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "javax.validation:validation-api:2.0.0.Final"
+    compile "javax.validation:validation-api:2.0.1.Final"
 
-    testCompile "org.hibernate:hibernate-validator:6.0.8.Final"
+    testCompile "org.hibernate:hibernate-validator:6.0.11.Final"
     testCompile "org.springframework.boot:spring-boot-starter-test:1.5.8.RELEASE"
     testCompile "commons-logging:commons-logging"
     testCompile "com.nhaarman:mockito-kotlin:1.5.0"

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.util.Optional
 import javax.validation.Validator
 
 @Configuration
@@ -77,9 +78,9 @@ class AwsKinesisAutoConfiguration {
         kinesisClientProvider: KinesisClientProvider,
         requestFactory: RequestFactory,
         streamInitializer: StreamInitializer,
-        validator: Validator? = null
+        validator: Optional<Validator> = Optional.empty()
     ): AwsKinesisOutboundGateway {
-        return AwsKinesisOutboundGateway(kinesisClientProvider, requestFactory, streamInitializer, validator)
+        return AwsKinesisOutboundGateway(kinesisClientProvider, requestFactory, streamInitializer, validator.orElse(null))
     }
 
     @Bean

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import javax.validation.Validator
 
 @Configuration
 @AutoConfigureAfter(name = ["org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration"])
@@ -75,9 +76,10 @@ class AwsKinesisAutoConfiguration {
     fun kinesisOutboundGateway(
         kinesisClientProvider: KinesisClientProvider,
         requestFactory: RequestFactory,
-        streamInitializer: StreamInitializer
+        streamInitializer: StreamInitializer,
+        validator: Validator? = null
     ): AwsKinesisOutboundGateway {
-        return AwsKinesisOutboundGateway(kinesisClientProvider, requestFactory, streamInitializer)
+        return AwsKinesisOutboundGateway(kinesisClientProvider, requestFactory, streamInitializer, validator)
     }
 
     @Bean

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisOutboundGateway.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisOutboundGateway.kt
@@ -1,11 +1,14 @@
 package de.bringmeister.spring.aws.kinesis
 
 import org.slf4j.LoggerFactory
+import javax.validation.ValidationException
+import javax.validation.Validator
 
 class AwsKinesisOutboundGateway(
     private val clientProvider: KinesisClientProvider,
     private val requestFactory: RequestFactory,
-    private val streamInitializer: StreamInitializer
+    private val streamInitializer: StreamInitializer,
+    private val validator: Validator? = null
 ) {
 
     private val log = LoggerFactory.getLogger(this.javaClass)
@@ -13,8 +16,13 @@ class AwsKinesisOutboundGateway(
     fun send(streamName: String, vararg records: Record<*, *>) {
         streamInitializer.createStreamIfMissing(streamName)
 
-        val kinesis = clientProvider.clientFor(streamName)
+        val violations = validator?.validate(records) ?: setOf()
+        if (violations.isNotEmpty()) {
+            throw ValidationException("invalid record: $violations")
+        }
+
         val request = requestFactory.request(streamName, *records)
+        val kinesis = clientProvider.clientFor(streamName)
 
         log.trace("Sending records to stream [{}] \nRecords: [{}]", streamName, records)
         val result = kinesis.putRecords(request)

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisOutboundGatewayTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisOutboundGatewayTest.kt
@@ -5,40 +5,74 @@ import com.amazonaws.services.kinesis.model.PutRecordsRequest
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.anyVararg
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Test
+import javax.validation.ValidationException
+import javax.validation.Validator
 
 class AwsKinesisOutboundGatewayTest {
 
     val requestFactory = mock<RequestFactory> { }
     val clientProvider = mock<KinesisClientProvider> { }
     val streamInitializer = mock<StreamInitializer>()
-    val outboundGateway = AwsKinesisOutboundGateway(clientProvider, requestFactory, streamInitializer)
+    val validator = mock<Validator>()
+    val outboundGateway = AwsKinesisOutboundGateway(clientProvider, requestFactory, streamInitializer, validator)
 
     @Test
     fun `should create and send kinesis request`() {
         val request = mock<PutRecordsRequest> { }
         val producer = mock<AmazonKinesis> { }
 
-        whenever(requestFactory.request(eq("foo-stream"), any<Record<FooCreatedEvent, EventMetadata>>())).thenReturn(request)
-        whenever(clientProvider.clientFor("foo-stream")).thenReturn(producer)
+        val streamName = "some-stream-name"
+        whenever(requestFactory.request(eq(streamName), any<Record<FooCreatedEvent, EventMetadata>>())).thenReturn(request)
+        whenever(clientProvider.clientFor(streamName)).thenReturn(producer)
         whenever(producer.putRecords(any())).thenReturn(mock { })
 
         val event = FooCreatedEvent("any-value")
         val metadata = mock<EventMetadata> { }
-        outboundGateway.send("foo-stream", Record(event, metadata))
+        outboundGateway.send(streamName, Record(event, metadata))
 
         val stringCaptor = argumentCaptor<String>()
         val dataCaptor = argumentCaptor<Record<FooCreatedEvent, EventMetadata>>()
         verify(requestFactory).request(stringCaptor.capture(), dataCaptor.capture())
-        assertThat(stringCaptor.firstValue, equalTo("foo-stream"))
+        assertThat(stringCaptor.firstValue, equalTo(streamName))
         assertThat(dataCaptor.firstValue.data, equalTo(event))
         assertThat(dataCaptor.firstValue.metadata, equalTo(metadata))
-        verify(clientProvider).clientFor("foo-stream")
+        verify(clientProvider).clientFor(streamName)
+        verify(producer).putRecords(request)
+    }
+
+    @Test(expected = ValidationException::class)
+    fun `should reject invalid event`() {
+        val streamName = "some-stream-name"
+        val invalidEvent = FooCreatedEvent(foo = "")
+
+        whenever(validator.validate(anyVararg<FooCreatedEvent>())).thenReturn(setOf(mock()))
+        verifyZeroInteractions(requestFactory)
+        verifyZeroInteractions(clientProvider)
+
+        outboundGateway.send(streamName, Record(invalidEvent, mock<EventMetadata> { }))
+    }
+
+    @Test
+    fun `should accept invalid event when no validator passed`() {
+        val streamName = "some-stream-name"
+        val invalidEvent = FooCreatedEvent(foo = "")
+        val request = mock<PutRecordsRequest> { }
+        val producer = mock<AmazonKinesis> { }
+        val outboundGatewayWithoutValidator = AwsKinesisOutboundGateway(clientProvider, requestFactory, streamInitializer)
+        whenever(requestFactory.request(eq(streamName), any<Record<FooCreatedEvent, EventMetadata>>())).thenReturn(request)
+        whenever(clientProvider.clientFor(streamName)).thenReturn(producer)
+        whenever(producer.putRecords(any())).thenReturn(mock { })
+
+        outboundGatewayWithoutValidator.send(streamName, Record(invalidEvent, mock<EventMetadata> { }))
+
         verify(producer).putRecords(request)
     }
 }

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/TestData.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/TestData.kt
@@ -1,4 +1,6 @@
 package de.bringmeister.spring.aws.kinesis
 
-data class FooCreatedEvent(val foo: String)
+import javax.validation.constraints.NotEmpty
+
+data class FooCreatedEvent(@get: NotEmpty val foo: String)
 data class EventMetadata(val sender: String)


### PR DESCRIPTION
adds an optional Validator to the OutboundGateway which throws an exception in case the record has a violation