### PR TITLE
Upgrade to Spring Boot 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         versions = [
                 kotlin    : '1.2.51',
-                springBoot: '1.5.8.RELEASE',
+                springBoot: '2.1.0.RELEASE',
                 kinesis   : '1.8.10',
                 awsSdk    : '1.11.280',
                 jackson   : '2.9.2'
@@ -45,6 +45,8 @@ configurations.all {
         force 'com.fasterxml.jackson.core:jackson-databind:2.9.2'
         force 'com.fasterxml.jackson.core:jackson-core:2.9.2'
         force 'org.assertj:assertj-core:3.9.1'
+        force 'org.yaml:snakeyaml:1.23'
+        force 'org.apache.logging.log4j:log4j-api:2.7'
     }
 }
 
@@ -70,6 +72,10 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+configurations {
+    all*.exclude module: 'commons-logging'
+}
+
 dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
@@ -82,13 +88,11 @@ dependencies {
     compile "javax.validation:validation-api:2.0.1.Final"
 
     testCompile "org.hibernate:hibernate-validator:6.0.11.Final"
-    testCompile "org.springframework.boot:spring-boot-starter-test:1.5.8.RELEASE"
-    testCompile "commons-logging:commons-logging"
+    testCompile "org.springframework.boot:spring-boot-starter-test:${versions.springBoot}"
     testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     testCompile "com.natpryce:hamkrest:1.4.2.2"
     testCompile "org.yaml:snakeyaml:1.20"
     testCompile "org.testcontainers:testcontainers:1.6.0"
-    testCompile "org.springframework.boot:spring-boot-starter-log4j2:1.5.8.RELEASE"
     testCompile "com.fasterxml.jackson.module:jackson-module-kotlin:${versions.jackson}"
     testCompile "org.assertj:assertj-core:3.9.1"
 }

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettingsTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettingsTest.kt
@@ -8,9 +8,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration
+import org.springframework.boot.context.properties.bind.BindException
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.junit4.SpringRunner
-import org.springframework.validation.BindException
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean
 
 @RunWith(SpringRunner::class)
@@ -24,7 +24,7 @@ class AwsKinesisProducerSettingsTest {
     fun `should read producer settings`() {
 
         val settings = builder<AwsKinesisSettings>()
-            .populate(AwsKinesisSettings())
+            .populate(AwsKinesisSettings::class.java)
             .withPrefix("aws.kinesis")
             .withProperty("region", "local")
             .withProperty("kinesis-url", "http://localhost:14567")
@@ -43,7 +43,7 @@ class AwsKinesisProducerSettingsTest {
     fun `should read consumer settings`() {
 
         val settings = builder<AwsKinesisSettings>()
-            .populate(AwsKinesisSettings())
+            .populate(AwsKinesisSettings::class.java)
             .withPrefix("aws.kinesis")
             .withProperty("region", "local")
             .withProperty("kinesis-url", "http://localhost:14567")
@@ -62,7 +62,7 @@ class AwsKinesisProducerSettingsTest {
     fun `should read default settings`() {
 
         val settings = builder<AwsKinesisSettings>()
-            .populate(AwsKinesisSettings())
+            .populate(AwsKinesisSettings::class.java)
             .withPrefix("aws.kinesis")
             .withProperty("region", "eu-central-1")
             .validateUsing(localValidatorFactoryBean)
@@ -80,7 +80,7 @@ class AwsKinesisProducerSettingsTest {
         val kinesisUrl = "http://localhost:1234/kinesis"
         val dynamoDbUrl = "http://localhost:1234/dynamodb"
         val settings = builder<AwsKinesisSettings>()
-            .populate(AwsKinesisSettings())
+            .populate(AwsKinesisSettings::class.java)
             .withPrefix("aws.kinesis")
             .withProperty("region", "local")
             .withProperty("kinesisUrl", kinesisUrl)
@@ -99,7 +99,7 @@ class AwsKinesisProducerSettingsTest {
     fun `should fail if region is missing`() {
 
         builder<AwsKinesisSettings>()
-            .populate(AwsKinesisSettings())
+            .populate(AwsKinesisSettings::class.java)
             .withPrefix("aws.kinesis")
             .withProperty("kinesis-url", "http://localhost:14567")
             .validateUsing(localValidatorFactoryBean)
@@ -110,7 +110,7 @@ class AwsKinesisProducerSettingsTest {
     fun `should allow retry configuration`() {
 
         val settings = builder<AwsKinesisSettings>()
-            .populate(AwsKinesisSettings())
+            .populate(AwsKinesisSettings::class.java)
             .withPrefix("aws.kinesis")
             .withProperty("region", "eu-central-1")
             .withProperty("retry.maxRetries", "3")
@@ -127,7 +127,7 @@ class AwsKinesisProducerSettingsTest {
         val kinesisUrl = "http://localhost:1234/kinesis"
         val dynamoDbUrl = "http://localhost:1234/dynamodb"
         builder<AwsKinesisSettings>()
-            .populate(AwsKinesisSettings())
+            .populate(AwsKinesisSettings::class.java)
             .withPrefix("aws.kinesis")
             .withProperty("region", "local")
             .withProperty("kinesisUrl", kinesisUrl)


### PR DESCRIPTION
I have upgraded to Spring Boot 2. Spring Boot 2 has removed the PropertiesConfigurationFactory which was used in our tests. Instead you should use Binder now (see https://spring.io/blog/2018/03/12/upgrading-start-spring-io-to-spring-boot-2#test-infrastructure). No big deal. 

I had a little bit trouble with the logging. I hope all dependencies are correct now.