### PR TITLE
Remove redundant `@Component` annotation

### DIFF
--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisListenerPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisListenerPostProcessor.kt
@@ -4,7 +4,6 @@ import org.springframework.beans.BeansException
 import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.stereotype.Component
 
-@Component
 class KinesisListenerPostProcessor(
     private val kinesisInboundGateway: AwsKinesisInboundGateway,
     private val kinesisListenerProxyFactory: KinesisListenerProxyFactory


### PR DESCRIPTION
Remove redundant `@Component` annotation

The relevant bean is also created via `AwsKinesisAutoConfiguration#kinesisListenerPostProcessor`.