### PR TITLE
Log sequence no when processing aws record.

### DIFF
--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisRecordProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisRecordProcessor.kt
@@ -50,7 +50,7 @@ class AwsKinesisRecordProcessor(
 
         val maxAttempts = 1 + configuration.maxRetries
         try {
-            log.trace("Stream [{}]: {}", handler.stream, recordJson)
+            log.trace("Stream [{}], Seq. No [{}]: {}", handler.stream, awsRecord.sequenceNumber, recordJson)
 
             val record = getRecordFromJson(recordJson)
 


### PR DESCRIPTION
To be able to reset the cursor of client consuming a stream, we need to know what events he already has processed.