### PR TITLE
WIP: Provide Spring Boot Actuator health support for workers and streams (in/out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ aws:
 
 By default, `validate` is turned on.
 
+#### Actuator health support
+
+By default, this starter exposes health information for each registered worker as well as stream (exists and available).
+This feature can be disable by setting `management.endpoint.health.<name>.enabled` flag to `false`.
+Name can be any of:
+
+* `kinesis`: disable completely
+* `kinesis.worker`: disable worker health
+* `kinesis.stream`: disable stream health
+
+```yaml
+management:
+  endpoint:
+    health:
+      kinesis:
+        enabled: false
+        worker:
+          enabled: false
+        stream:
+          enabled: false
+```
+
 #### Configuring initial position in stream
 
 You can use one of following values:

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     testCompile "org.testcontainers:testcontainers:1.10.1"
     testCompile "com.fasterxml.jackson.module:jackson-module-kotlin"
+    testCompile 'org.awaitility:awaitility:3.1.5'
 }
 
 task sourceJar(type: Jar) {

--- a/src/integrationTest/java/de/bringmeister/spring/aws/kinesis/JavaListenerTest.java
+++ b/src/integrationTest/java/de/bringmeister/spring/aws/kinesis/JavaListenerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.GenericContainer;
 import de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration;
+import de.bringmeister.spring.aws.kinesis.health.KinesisHealthAutoConfiguration;
 import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration;
 
 import java.util.concurrent.CountDownLatch;
@@ -31,7 +32,8 @@ import java.util.function.Consumer;
         KinesisLocalConfiguration.class,
         AwsKinesisAutoConfiguration.class,
         KinesisCreateStreamAutoConfiguration.class,
-        KinesisValidationAutoConfiguration.class
+        KinesisValidationAutoConfiguration.class,
+        KinesisHealthAutoConfiguration.class
     },
     properties = {
         "aws.kinesis.initial-position-in-stream: TRIM_HORIZON"

--- a/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/KotlinListenerTest.kt
+++ b/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/KotlinListenerTest.kt
@@ -16,6 +16,7 @@ import org.testcontainers.containers.GenericContainer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration
+import de.bringmeister.spring.aws.kinesis.health.KinesisHealthAutoConfiguration
 import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration
 
 @ActiveProfiles("kinesis-local")
@@ -27,7 +28,8 @@ import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfig
         KinesisLocalConfiguration::class,
         AwsKinesisAutoConfiguration::class,
         KinesisCreateStreamAutoConfiguration::class,
-        KinesisValidationAutoConfiguration::class
+        KinesisValidationAutoConfiguration::class,
+        KinesisHealthAutoConfiguration::class
     ],
     properties = [
         "aws.kinesis.initial-position-in-stream: TRIM_HORIZON"

--- a/src/main/kotlin/de/bringmeister/spring/aws/health/AbstractAwsHealthIndicator.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/health/AbstractAwsHealthIndicator.kt
@@ -1,0 +1,45 @@
+package de.bringmeister.spring.aws.health
+
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException
+import org.springframework.boot.actuate.health.AbstractHealthIndicator
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Status
+import java.util.concurrent.atomic.AtomicBoolean
+
+abstract class AbstractAwsHealthIndicator<S : Enum<*>>(
+    private val type: String,
+    val name: String,
+    ignoreNotFoundUntilCreated: Boolean
+) : AbstractHealthIndicator("Health check failed for $type <$name>") {
+
+    private val ignoreNotFound = AtomicBoolean(ignoreNotFoundUntilCreated)
+
+    override fun doHealthCheck(builder: Health.Builder) {
+
+        val ignoreNotFound = this.ignoreNotFound.get()
+        builder
+            .withDetail("$type-name", name)
+            .withDetail("$type-status", "NOT_FOUND")
+
+        try {
+            val status = getStatus(name)
+            if (ignoreNotFound) {
+                this.ignoreNotFound.set(false)
+            }
+            builder
+                .withDetail("$type-status", status)
+                .status(toHealthStatus(status))
+        } catch (ex: ResourceNotFoundException) {
+            when (ignoreNotFound) {
+                true -> {
+                    builder.unknown()
+                    return
+                }
+                false -> throw ex
+            }
+        }
+    }
+
+    protected abstract fun getStatus(name: String): S
+    protected abstract fun toHealthStatus(status: S): Status
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/CompositeKinesisHealthIndicator.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/CompositeKinesisHealthIndicator.kt
@@ -1,0 +1,43 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.actuate.health.CompositeHealthIndicator
+import org.springframework.boot.actuate.health.DefaultHealthIndicatorRegistry
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.HealthIndicatorRegistry
+import org.springframework.boot.actuate.health.OrderedHealthAggregator
+
+class CompositeKinesisHealthIndicator(
+    private val registry: HealthIndicatorRegistry = DefaultHealthIndicatorRegistry()
+) : HealthIndicator by CompositeHealthIndicator(OrderedHealthAggregator(), registry) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun registerWorker(indicator: WorkerHealthInboundHandler<*, *>): Unregister {
+        val name = "worker::${indicator.stream}"
+        registerReplaceExisting(name, indicator)
+        return unregisterHandler(name)
+    }
+
+    fun registerStream(indicator: KinesisStreamHealthIndicator): Unregister {
+        val name = "stream::${indicator.name}"
+        registerReplaceExisting(name, indicator)
+        return unregisterHandler(name)
+    }
+
+    @Synchronized
+    private fun registerReplaceExisting(name: String, indicator: HealthIndicator) {
+        if (registry.unregister(name) != null) {
+            log.debug("Replacing existing health indicator [{}]...", name)
+        } else {
+            log.debug("Adding health indicator [{}]...", name)
+        }
+        registry.register(name, indicator)
+    }
+
+    private fun unregisterHandler(name: String): Unregister {
+        return { registry.unregister(name) }
+    }
+}
+
+private typealias Unregister = () -> HealthIndicator

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisHealthAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisHealthAutoConfiguration.kt
@@ -1,0 +1,46 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import de.bringmeister.spring.aws.kinesis.AwsKinesisAutoConfiguration
+import de.bringmeister.spring.aws.kinesis.AwsKinesisSettings
+import de.bringmeister.spring.aws.kinesis.KinesisClientProvider
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+
+@Configuration
+@ConditionalOnClass(HealthIndicator::class)
+@ConditionalOnEnabledHealthIndicator("kinesis")
+@AutoConfigureBefore(AwsKinesisAutoConfiguration::class)
+class KinesisHealthAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun kinesisHealthIndicator() = CompositeKinesisHealthIndicator()
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnEnabledHealthIndicator("kinesis.worker")
+    fun workerHealthInboundHandlerPostProcessor(
+        composite: CompositeKinesisHealthIndicator
+    ) = WorkerHealthInboundHandlerPostProcessor(composite)
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnEnabledHealthIndicator("kinesis.stream")
+    fun kinesisStreamHealthOutboundStreamPostProcessor(
+        composite: CompositeKinesisHealthIndicator,
+        clientProvider: KinesisClientProvider,
+        kinesisSettings: AwsKinesisSettings,
+        environment: Environment
+    ) = KinesisStreamHealthPostProcessor(
+        composite = composite,
+        clientProvider = clientProvider,
+        ignoreNotFoundUntilCreated = kinesisSettings.createStreams,
+        useSummaryApi = !environment.activeProfiles.contains("kinesis-local")
+    )
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthIndicator.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthIndicator.kt
@@ -1,0 +1,34 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import com.amazonaws.services.kinesis.AmazonKinesis
+import com.amazonaws.services.kinesis.model.DescribeStreamSummaryRequest
+import com.amazonaws.services.kinesis.model.StreamStatus
+import de.bringmeister.spring.aws.health.AbstractAwsHealthIndicator
+import org.springframework.boot.actuate.health.Status
+
+class KinesisStreamHealthIndicator(
+    stream: String,
+    private val kinesis: AmazonKinesis,
+    ignoreNotFoundUntilCreated: Boolean,
+    private val useSummaryApi: Boolean
+) : AbstractAwsHealthIndicator<StreamStatus>("stream", stream, ignoreNotFoundUntilCreated) {
+
+    private val summaryRequest = DescribeStreamSummaryRequest().withStreamName(name)
+
+    override fun getStatus(name: String): StreamStatus {
+        // describeStreamSummary is not available from Dockerized kinesis
+        val streamStatus = when(useSummaryApi) {
+            true -> kinesis.describeStreamSummary(summaryRequest).streamDescriptionSummary.streamStatus
+            false -> kinesis.describeStream(name).streamDescription.streamStatus
+        }
+        return StreamStatus.fromValue(streamStatus)
+    }
+
+    override fun toHealthStatus(status: StreamStatus): Status
+        = when (status) {
+            StreamStatus.UPDATING, StreamStatus.CREATING -> Status.UNKNOWN
+            StreamStatus.ACTIVE -> Status.UP
+            StreamStatus.DELETING -> Status.DOWN
+            else -> Status.UNKNOWN
+        }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthPostProcessor.kt
@@ -1,0 +1,34 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import de.bringmeister.spring.aws.kinesis.KinesisClientProvider
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandlerPostProcessor
+import de.bringmeister.spring.aws.kinesis.KinesisOutboundStream
+import de.bringmeister.spring.aws.kinesis.KinesisOutboundStreamPostProcessor
+
+class KinesisStreamHealthPostProcessor(
+    private val composite: CompositeKinesisHealthIndicator,
+    private val clientProvider: KinesisClientProvider,
+    private val ignoreNotFoundUntilCreated: Boolean = false,
+    private val useSummaryApi: Boolean = true
+) : KinesisOutboundStreamPostProcessor, KinesisInboundHandlerPostProcessor {
+
+    override fun postProcess(handler: KinesisInboundHandler<*, *>): KinesisInboundHandler<*, *> {
+        composite.registerStream(indicator(handler.stream))
+        return handler
+    }
+
+    override fun postProcess(stream: KinesisOutboundStream): KinesisOutboundStream {
+        composite.registerStream(indicator(stream.stream))
+        return stream
+    }
+
+    private fun indicator(stream: String): KinesisStreamHealthIndicator {
+        return KinesisStreamHealthIndicator(
+            stream = stream,
+            kinesis = clientProvider.clientFor(stream),
+            ignoreNotFoundUntilCreated = ignoreNotFoundUntilCreated,
+            useSummaryApi = useSummaryApi
+        )
+    }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandler.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandler.kt
@@ -1,0 +1,30 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.Status
+
+class WorkerHealthInboundHandler<D, M>(
+    private val delegate: KinesisInboundHandler<D, M>
+) : KinesisInboundHandler<D, M> by delegate, HealthIndicator {
+
+    private var health = health(Status.UNKNOWN)
+
+    override fun ready() {
+        delegate.ready()
+        health = health(Status.UP)
+    }
+
+    override fun shutdown() {
+        health = health(Status.DOWN)
+        delegate.shutdown()
+    }
+
+    override fun health() = health
+
+    private fun health(status: Status): Health
+        = Health.status(status)
+            .withDetail("stream-name", stream)
+            .build()
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerPostProcessor.kt
@@ -1,0 +1,15 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandlerPostProcessor
+
+class WorkerHealthInboundHandlerPostProcessor(
+    private val composite: CompositeKinesisHealthIndicator
+) : KinesisInboundHandlerPostProcessor {
+
+    override fun postProcess(handler: KinesisInboundHandler<*, *>): KinesisInboundHandler<*, *> {
+        val decorated = WorkerHealthInboundHandler(handler)
+        composite.registerWorker(decorated)
+        return decorated
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=de.bringmeister.spring.aws.kinesis.AwsKinesisAutoConfiguration,\
 de.bringmeister.spring.aws.kinesis.KinesisLocalConfiguration, \
 de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration, \
-de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration
+de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration, \
+de.bringmeister.spring.aws.kinesis.health.KinesisHealthAutoConfiguration

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/CompositeKinesisHealthIndicatorTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/CompositeKinesisHealthIndicatorTest.kt
@@ -1,0 +1,59 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import com.nhaarman.mockito_kotlin.mock
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.actuate.health.DefaultHealthIndicatorRegistry
+
+class CompositeKinesisHealthIndicatorTest {
+
+    @Test
+    fun `should register, override and unregister worker health indicator`() {
+        val registry = DefaultHealthIndicatorRegistry()
+        val composite = CompositeKinesisHealthIndicator(registry)
+
+        val delegate = TestKinesisInboundHandler()
+        val indicator1 = WorkerHealthInboundHandler(delegate)
+        composite.registerWorker(indicator1)
+        assertThat(registry["worker::${delegate.stream}"]).isNotNull
+        assertThat(registry.all).hasSize(1)
+
+        val indicator2 = WorkerHealthInboundHandler(delegate)
+        val disposable = composite.registerWorker(indicator2)
+        assertThat(registry["worker::${delegate.stream}"]).isNotNull
+        assertThat(registry.all).hasSize(1)
+
+        disposable()
+        assertThat(registry.all).isEmpty()
+    }
+
+    @Test
+    fun `should register, override and unregister stream health indicator`() {
+        val registry = DefaultHealthIndicatorRegistry()
+        val composite = CompositeKinesisHealthIndicator(registry)
+
+        val indicator1 = KinesisStreamHealthIndicator(
+            stream = "test",
+            kinesis = mock {},
+            ignoreNotFoundUntilCreated = true,
+            useSummaryApi = true
+        )
+        composite.registerStream(indicator1)
+        assertThat(registry["stream::test"]).isNotNull
+        assertThat(registry.all).hasSize(1)
+
+        val indicator2 = KinesisStreamHealthIndicator(
+            stream = "test",
+            kinesis = mock {},
+            ignoreNotFoundUntilCreated = true,
+            useSummaryApi = true
+        )
+        val disposable = composite.registerStream(indicator2)
+        assertThat(registry["stream::test"]).isNotNull
+        assertThat(registry.all).hasSize(1)
+
+        disposable()
+        assertThat(registry.all).isEmpty()
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthIndicatorIntegrationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthIndicatorIntegrationTest.kt
@@ -1,0 +1,93 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest
+import com.amazonaws.waiters.WaiterParameters
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Status
+import org.testcontainers.containers.GenericContainer
+
+class KinesisStreamHealthIndicatorIntegrationTest {
+
+    companion object {
+        class KGenericContainer(imageName: String) : GenericContainer<KGenericContainer>(imageName)
+
+        @ClassRule
+        @JvmField
+        val kinesis = KGenericContainer("instructure/kinesalite:latest")
+            .withExposedPorts(4567)
+
+        @BeforeClass
+        @JvmStatic
+        fun enableAwsSdkCreateResourcesCapability() {
+            System.setProperty("com.amazonaws.sdk.disableCbor", "1")
+        }
+    }
+
+    @Test
+    fun `should correctly report stream status when treating missing initial stream as DOWN`()
+        = `should correctly report stream status`(
+            streamName = "test-stream-1",
+            ignoreNotFoundUntilCreated = false,
+            expectedInitialStatus = Status.DOWN
+        )
+
+    @Test
+    fun `should correctly report stream status when treating missing initial stream as UNKNOWN`()
+        = `should correctly report stream status`(
+            streamName = "test-stream-2",
+            ignoreNotFoundUntilCreated = true,
+            expectedInitialStatus = Status.UNKNOWN
+        )
+
+    private fun `should correctly report stream status`(
+        streamName: String,
+        ignoreNotFoundUntilCreated: Boolean,
+        expectedInitialStatus: Status
+    ) {
+
+        val kinesis = kinesis()
+        val indicator = KinesisStreamHealthIndicator(
+            stream = streamName,
+            kinesis = kinesis,
+            ignoreNotFoundUntilCreated = ignoreNotFoundUntilCreated,
+            useSummaryApi = false // <true> not supported by Docker image
+        )
+        assertHealth(indicator.health(), expectedInitialStatus, streamName)
+
+        kinesis.createStream(streamName, 1)
+        kinesis.waiters()
+            .streamExists()
+            .run(WaiterParameters(DescribeStreamRequest().withStreamName(streamName)))
+        assertHealth(indicator.health(), Status.UP, streamName)
+
+        kinesis.deleteStream(streamName)
+        kinesis.waiters()
+            .streamNotExists()
+            .run(WaiterParameters(DescribeStreamRequest().withStreamName(streamName)))
+        assertHealth(indicator.health(), Status.DOWN, streamName)
+    }
+
+    private fun assertHealth(health: Health, expectedStatus: Status, exectedStreamName: String) {
+        assertThat(health.status).isEqualTo(expectedStatus)
+        assertThat(health.details)
+            .containsEntry("stream-name", exectedStreamName)
+            .containsKey("stream-status")
+    }
+
+    private val kinesisEndpoint = "http://${kinesis.containerIpAddress}:${kinesis.getMappedPort(4567)}"
+    private val credentialsProvider = AWSStaticCredentialsProvider(BasicAWSCredentials("access", "secret"))
+
+    private fun kinesis()
+            = AmazonKinesisClientBuilder.standard()
+        .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(kinesisEndpoint, "TEST_REGION"))
+        .withCredentials(credentialsProvider)
+        .build()
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthIndicatorTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthIndicatorTest.kt
@@ -1,0 +1,22 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.actuate.health.Status
+
+class KinesisStreamHealthIndicatorTest {
+
+    @Test
+    fun `should indicate DOWN on error`() {
+        val indicator = KinesisStreamHealthIndicator(
+            kinesis = mock { },
+            stream = "test",
+            useSummaryApi = true,
+            ignoreNotFoundUntilCreated = false
+        )
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.DOWN)
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthPostProcessorTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisStreamHealthPostProcessorTest.kt
@@ -1,0 +1,50 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import com.amazonaws.services.kinesis.AmazonKinesis
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import de.bringmeister.spring.aws.kinesis.KinesisClientProvider
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.TestKinesisOutboundStream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.actuate.health.DefaultHealthIndicatorRegistry
+
+class KinesisStreamHealthPostProcessorTest {
+
+    private val mockClientProvider = mock<KinesisClientProvider> {
+        on { clientFor("test") } doReturn mock<AmazonKinesis> { }
+    }
+
+    @Test
+    fun `should register health indicator in composite for inbound`() {
+
+        val registry = DefaultHealthIndicatorRegistry()
+        val processor = KinesisStreamHealthPostProcessor(
+            composite = CompositeKinesisHealthIndicator(registry),
+            clientProvider = mockClientProvider
+        )
+
+        val handler = TestKinesisInboundHandler()
+        val decorated = processor.postProcess(handler)
+
+        assertThat(registry["stream::${handler.stream}"]).isNotNull
+        assertThat(handler).isSameAs(decorated)
+    }
+
+    @Test
+    fun `should register health indicator in composite for outbound`() {
+
+        val registry = DefaultHealthIndicatorRegistry()
+        val processor = KinesisStreamHealthPostProcessor(
+            composite = CompositeKinesisHealthIndicator(registry),
+            clientProvider = mockClientProvider
+        )
+
+        val stream = TestKinesisOutboundStream()
+        val decorated = processor.postProcess(stream)
+
+        assertThat(registry["stream::${stream.stream}"]).isNotNull
+        assertThat(stream).isSameAs(decorated)
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerIntegrationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerIntegrationTest.kt
@@ -1,0 +1,161 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.verify
+import de.bringmeister.spring.aws.kinesis.AwsKinesisSettings
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.WorkerFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.awaitility.Duration
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Status
+import org.testcontainers.containers.GenericContainer
+
+class WorkerHealthInboundHandlerIntegrationTest {
+
+    companion object {
+
+        class KGenericContainer(imageName: String) : GenericContainer<KGenericContainer>(imageName)
+
+        @ClassRule
+        @JvmField
+        val kinesis = KGenericContainer("instructure/kinesalite:latest")
+            .withExposedPorts(4567)
+
+        @ClassRule
+        @JvmField
+        val dynamodb = KGenericContainer("richnorth/dynalite:latest")
+            .withExposedPorts(4567)
+
+        @BeforeClass
+        @JvmStatic
+        fun enableAwsSdkCreateResourcesCapability() {
+            System.setProperty("com.amazonaws.sdk.disableCbor", "1")
+        }
+    }
+
+    @Test
+    fun `should correctly signal worker health during full lifecycle (start, run, shutdown)`() {
+
+        val streamName = "test-stream-1"
+        kinesis().createStream(streamName, 1)
+
+        val workerFactory = workerFactory(streamName)
+        val mockHandler = mock<KinesisInboundHandler<*, *>> {
+            on { stream } doReturn streamName
+        }
+        val indicator = WorkerHealthInboundHandler(mockHandler)
+        val worker = workerFactory.worker(indicator, mock {})
+
+        // worker not yet started
+        assertHealth(indicator.health(), Status.UNKNOWN, streamName)
+        verify(mockHandler, never()).ready()
+        verify(mockHandler, never()).shutdown()
+        verify(mockHandler, never()).handleRecord(any(), any())
+
+        // start worker...
+        Thread(worker)
+            .apply { name = "${javaClass.simpleName}::thread" }
+            .start()
+        await()
+            .atMost(Duration.ONE_MINUTE)
+            .untilAsserted { verify(mockHandler).ready() }
+
+        // once started
+        assertHealth(indicator.health(), Status.UP, streamName)
+        verify(mockHandler).ready()
+        verify(mockHandler, never()).shutdown()
+        verify(mockHandler, never()).handleRecord(any(), any())
+
+        // shutdown worker...
+        worker.shutdown()
+        await()
+            .atMost(Duration.TEN_SECONDS)
+            .untilAsserted { verify(mockHandler).ready() }
+
+        // once worker is shutdown
+        assertHealth(indicator.health(), Status.DOWN, streamName)
+        verify(mockHandler).ready()
+        verify(mockHandler).shutdown()
+        verify(mockHandler, never()).handleRecord(any(), any())
+    }
+
+    @Test
+    fun `should correctly signal worker health when initialization fails`() {
+
+        val streamName = "test-stream-2"
+        // We do *not* create the stream causing the worker to fail.
+        // > kinesis().createStream(streamName, 1)
+
+        val workerFactory = workerFactory(streamName)
+        val mockHandler = mock<KinesisInboundHandler<*, *>> {
+            on { stream } doReturn streamName
+        }
+        val indicator = WorkerHealthInboundHandler(mockHandler)
+        val worker = workerFactory.worker(indicator, mock {})
+
+        // start worker...
+        Thread(worker)
+            .apply { name = "${javaClass.simpleName}::thread" }
+            .start()
+        await()
+            .atMost(Duration.ONE_MINUTE)
+            .untilAsserted { verify(mockHandler).shutdown() }
+
+        // failed to start
+        assertHealth(indicator.health(), Status.DOWN, streamName)
+        verify(mockHandler, never()).ready()
+        verify(mockHandler).shutdown()
+        verify(mockHandler, never()).handleRecord(any(), any())
+    }
+
+    private fun assertHealth(health: Health, expectedStatus: Status, exectedStreamName: String) {
+        assertThat(health.status).isEqualTo(expectedStatus)
+        assertThat(health.details).containsEntry("stream-name", exectedStreamName)
+    }
+
+    private val kinesisEndpoint = "http://${kinesis.containerIpAddress}:${kinesis.getMappedPort(4567)}"
+    private val credentialsProvider = AWSStaticCredentialsProvider(BasicAWSCredentials("access", "secret"))
+
+    private fun workerFactory(streamName: String)
+        = WorkerFactory(
+            clientConfigFactory = mock {
+                on { consumerConfig(streamName) } doReturn kinesisClientConfig(streamName)
+            },
+            settings = AwsKinesisSettings(),
+            applicationEventPublisher = mock {}
+        )
+
+    private fun kinesisClientConfig(streamName: String)
+        = KinesisClientLibConfiguration(
+            javaClass.simpleName,
+            streamName,
+            credentialsProvider,
+            "${javaClass.simpleName}::worker"
+        )
+        // It is not possible to set the retry attempts for worker initialization (20).
+        // Therefore, we set the wait time between failed attempts to 1ms and make the
+        // 20 retries happen as fast as possible.
+        .withParentShardPollIntervalMillis(1)
+        .withKinesisEndpoint(kinesisEndpoint)
+        .withDynamoDBEndpoint("http://${dynamodb.containerIpAddress}:${dynamodb.getMappedPort(4567)}")
+        .withMetricsLevel("NONE") // avoid CloudWatch error logs
+
+    private fun kinesis()
+        = AmazonKinesisClientBuilder.standard()
+            .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(kinesisEndpoint, "TEST_REGION"))
+            .withCredentials(credentialsProvider)
+            .build()
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerPostProcessorTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerPostProcessorTest.kt
@@ -1,0 +1,23 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.actuate.health.DefaultHealthIndicatorRegistry
+
+class WorkerHealthInboundHandlerPostProcessorTest {
+
+    @Test
+    fun `should register health indicator in composite`() {
+
+        val registry = DefaultHealthIndicatorRegistry()
+        val processor = WorkerHealthInboundHandlerPostProcessor(CompositeKinesisHealthIndicator(registry))
+
+        val handler = TestKinesisInboundHandler()
+        val decorated = processor.postProcess(handler)
+
+        assertThat(registry["worker::${handler.stream}"])
+            .isSameAs(decorated)
+            .isInstanceOf(WorkerHealthInboundHandler::class.java)
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/health/WorkerHealthInboundHandlerTest.kt
@@ -1,0 +1,61 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.Record
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Status
+
+class WorkerHealthInboundHandlerTest {
+
+    private val mockDelegate = mock<KinesisInboundHandler<Any, Any>> {
+        on { stream } doReturn "test"
+    }
+
+    @Test
+    fun `should changes state to up upon ready`() {
+        val handler = WorkerHealthInboundHandler(mockDelegate)
+        handler.ready()
+        assertHealth(handler.health(), Status.UP)
+    }
+
+    @Test
+    fun `should changes state to down upon shutdown`() {
+        val handler = WorkerHealthInboundHandler(mockDelegate)
+        handler.shutdown()
+        assertHealth(handler.health(), Status.DOWN)
+    }
+
+    @Test
+    fun `should have unknown state initially`() {
+        val handler = WorkerHealthInboundHandler(mockDelegate)
+        assertHealth(handler.health(), Status.UNKNOWN)
+    }
+
+    @Test
+    fun `should return stream name of delegate`() {
+        val handler = WorkerHealthInboundHandler(mockDelegate)
+        assertThat(handler.stream).isEqualTo("test")
+    }
+
+    @Test
+    fun `should delegate message handling`() {
+        val handler = WorkerHealthInboundHandler(mockDelegate)
+        val record = Record(Any(), Any())
+        val context = TestKinesisInboundHandler.TestExecutionContext()
+
+        handler.handleRecord(record, context)
+
+        verify(mockDelegate).handleRecord(record, context)
+    }
+
+    private fun assertHealth(health: Health, status: Status) {
+        assertThat(health.status).isEqualTo(status)
+        assertThat(health.details).containsEntry("stream-name", "test")
+    }
+}


### PR DESCRIPTION
_(Contains PR #63)_

Health information is exposed separate under a composite endpoint at `/actuator/health/kinesis`:
* The status (up/down) of each `@KinesisListener` is indicated with key `worker::{stream-name}`.
* The status of each stream (existing, creating, ...) is indicated with key `stream::{stream-name}`.

Health support is optional and available only if `spring-boot-starter-actuator` is
on the classpath. It may be deactivated by setting `management.health.kinesis.enabled`
to `false` (`management.health.kinesis.worker.enabled` or
`management.health.kinesis.stream.enabled`).
