### PR TITLE
Fix the broken integration tests.

### DIFF
--- a/src/integrationTest/java/de/bringmeister/spring/aws/kinesis/JavaListenerTest.java
+++ b/src/integrationTest/java/de/bringmeister/spring/aws/kinesis/JavaListenerTest.java
@@ -1,5 +1,7 @@
 package de.bringmeister.spring.aws.kinesis;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
@@ -19,13 +21,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 @ActiveProfiles("kinesis-local")
-@SpringBootTest(classes = {
+@SpringBootTest(
+    classes = {
         JavaTestListener.class,
         JacksonConfiguration.class,
         JacksonAutoConfiguration.class,
         KinesisLocalConfiguration.class,
         AwsKinesisAutoConfiguration.class
-})
+    },
+    properties = {
+        "aws.kinesis.initial-position-in-stream: TRIM_HORIZON"
+    }
+)
 @RunWith(SpringRunner.class)
 public class JavaListenerTest {
 
@@ -58,9 +65,8 @@ public class JavaListenerTest {
 
         outbound.send("foo-event-stream", new Record(fooEvent, metadata));
 
-        LATCH.await(1, TimeUnit.MINUTES); // wait for event-listener thread to process event
+        boolean messageReceived = LATCH.await(1, TimeUnit.MINUTES); // wait for event-listener thread to process event
 
-        // If we come to this point, the LATCH was counted down!
-        // This means the event has been consumed - test succeeded!
+        assertThat(messageReceived).isTrue();
     }
 }

--- a/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/KotlinListenerTest.kt
+++ b/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/KotlinListenerTest.kt
@@ -3,6 +3,7 @@ package de.bringmeister.spring.aws.kinesis
 import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.PortBinding
 import com.github.dockerjava.api.model.Ports
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.ClassRule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,6 +24,9 @@ import java.util.concurrent.TimeUnit
         JacksonAutoConfiguration::class,
         KinesisLocalConfiguration::class,
         AwsKinesisAutoConfiguration::class
+    ],
+    properties = [
+        "aws.kinesis.initial-position-in-stream: TRIM_HORIZON"
     ]
 )
 @RunWith(SpringRunner::class)
@@ -58,10 +62,9 @@ class KotlinListenerTest {
 
         outbound.send("foo-event-stream", Record(fooEvent, metadata))
 
-        latch.await(1, TimeUnit.MINUTES) // wait for event-listener thread to process event
+        val messageReceived = latch.await(1, TimeUnit.MINUTES) // wait for event-listener thread to process event
 
-        // If we come to this point, the LATCH was counted down!
-        // This means the event has been consumed - test succeeded!
+        assertThat(messageReceived).isTrue()
     }
 }
 


### PR DESCRIPTION
In order to know the success status the return value of `CountDownLatch.await`
has to be asserted, since it differentiates timeout from success.

Also, the tests were actually failing ever since the introduction of
setting `initial-position-in-stream` or maybe even before.

---

PS: Can someone of you please either make the tests compile and run in IntelliJ out-of-the-box or move them into the standard test folder. I always have to copy them into the test folder, fix them there and move them back. Crazy annoying this broken setup.