### PR TITLE
Implement put/get metrics controlled by setting `aws.kinesis.metrics`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,8 @@ aws:
 ```
 
 The following metrics are recorded and tagged with `stream` and `exception` (default `None`):
-* `aws.kinesis.starter.inbound.time`: Duration of calls to `KinesisInboundHandler.handleRecord` (+ tag `retry`)
-* `aws.kinesis.starter.inbound.count`: Count of calls to `KinesisInboundHandler.handleRecord` (+ tag `retry`)
-* `aws.kinesis.starter.outbound.time`: Duration of calls to `KinesisOutboundStream.send`
-* `aws.kinesis.starter.outbound.count`: Count of calls to `KinesisOutboundStream.send`
+* `aws.kinesis.starter.inbound`: Duration of calls to `KinesisInboundHandler.handleRecord` (+ tag `retry`)
+* `aws.kinesis.starter.outbound`: Duration of calls to `KinesisOutboundStream.send`
 
 By default, `metrics` is turned on.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ aws:
 
 By default, `validate` is turned on.
 
+#### Metrics
+
+This starter reports metrics about records send and received when `io.micrometer:micrometer-core` is found on classpath.
+This feature can be disable by setting `metrics` flag to `false`:
+
+```yaml
+aws:
+  kinesis:
+    ...
+    metrics: false
+```
+
+The following metrics are recorded and tagged with `stream` and `exception` (default `None`):
+* `aws.kinesis.starter.inbound.time`: Duration of calls to `KinesisInboundHandler.handleRecord` (+ tag `retry`)
+* `aws.kinesis.starter.inbound.count`: Count of calls to `KinesisInboundHandler.handleRecord` (+ tag `retry`)
+* `aws.kinesis.starter.outbound.time`: Duration of calls to `KinesisOutboundStream.send`
+* `aws.kinesis.starter.outbound.count`: Count of calls to `KinesisOutboundStream.send`
+
+By default, `metrics` is turned on.
+
 #### Configuring initial position in stream
 
 You can use one of following values:

--- a/src/integrationTest/java/de/bringmeister/spring/aws/kinesis/JavaListenerTest.java
+++ b/src/integrationTest/java/de/bringmeister/spring/aws/kinesis/JavaListenerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.GenericContainer;
 import de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration;
+import de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration;
 import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration;
 
 import java.util.concurrent.CountDownLatch;
@@ -31,7 +32,8 @@ import java.util.function.Consumer;
         KinesisLocalConfiguration.class,
         AwsKinesisAutoConfiguration.class,
         KinesisCreateStreamAutoConfiguration.class,
-        KinesisValidationAutoConfiguration.class
+        KinesisValidationAutoConfiguration.class,
+        KinesisMetricsAutoConfiguration.class
     },
     properties = {
         "aws.kinesis.initial-position-in-stream: TRIM_HORIZON"

--- a/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/KotlinListenerTest.kt
+++ b/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/KotlinListenerTest.kt
@@ -16,6 +16,7 @@ import org.testcontainers.containers.GenericContainer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration
+import de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration
 import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration
 
 @ActiveProfiles("kinesis-local")
@@ -27,7 +28,8 @@ import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfig
         KinesisLocalConfiguration::class,
         AwsKinesisAutoConfiguration::class,
         KinesisCreateStreamAutoConfiguration::class,
-        KinesisValidationAutoConfiguration::class
+        KinesisValidationAutoConfiguration::class,
+        KinesisMetricsAutoConfiguration::class
     ],
     properties = [
         "aws.kinesis.initial-position-in-stream: TRIM_HORIZON"

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
@@ -3,7 +3,9 @@ package de.bringmeister.spring.aws.kinesis
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.fasterxml.jackson.databind.ObjectMapper
+import jdk.nashorn.internal.runtime.regexp.joni.Config.log
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -18,8 +20,6 @@ import org.springframework.context.annotation.Configuration
 @AutoConfigureAfter(name = ["org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration"])
 @EnableConfigurationProperties(AwsKinesisSettings::class)
 class AwsKinesisAutoConfiguration {
-
-    private val log = LoggerFactory.getLogger(javaClass)
 
     @Bean
     @ConditionalOnMissingBean
@@ -90,11 +90,9 @@ class AwsKinesisAutoConfiguration {
     fun kinesisOutboundStreamFactory(
         kinesisClientProvider: KinesisClientProvider,
         requestFactory: RequestFactory,
-        @Autowired(required = false) postProcessors: List<KinesisOutboundStreamPostProcessor>?
+        postProcessors: ObjectProvider<KinesisOutboundStreamPostProcessor>
     ): KinesisOutboundStreamFactory {
-        val pp = postProcessors ?: emptyList()
-        log.debug("Registering {} KinesisOutboundStreamPostProcessors: [{}]", pp.size, pp)
-        return AwsKinesisOutboundStreamFactory(kinesisClientProvider, requestFactory, pp)
+        return AwsKinesisOutboundStreamFactory(kinesisClientProvider, requestFactory, postProcessors)
     }
 
     @Bean
@@ -103,11 +101,9 @@ class AwsKinesisAutoConfiguration {
         workerFactory: WorkerFactory,
         workerStarter: WorkerStarter,
         recordDeserializerFactory: RecordDeserializerFactory,
-        @Autowired(required = false) postProcessors: List<KinesisInboundHandlerPostProcessor>?
+        postProcessors: ObjectProvider<KinesisInboundHandlerPostProcessor>
     ): AwsKinesisInboundGateway {
-        val pp = postProcessors ?: emptyList()
-        log.debug("Registering {} KinesisInboundHandlerPostProcessor: [{}]", pp.size, pp)
-        return AwsKinesisInboundGateway(workerFactory, workerStarter, recordDeserializerFactory, pp)
+        return AwsKinesisInboundGateway(workerFactory, workerStarter, recordDeserializerFactory, postProcessors)
     }
 
     @Bean

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
@@ -3,10 +3,7 @@ package de.bringmeister.spring.aws.kinesis
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.fasterxml.jackson.databind.ObjectMapper
-import jdk.nashorn.internal.runtime.regexp.joni.Config.log
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisInboundGateway.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisInboundGateway.kt
@@ -7,7 +7,7 @@ class AwsKinesisInboundGateway(
     private val workerFactory: WorkerFactory,
     private val workerStarter: WorkerStarter,
     private val recordDeserializerFactory: RecordDeserializerFactory,
-    private val handlerPostProcessors: List<KinesisInboundHandlerPostProcessor> = emptyList()
+    private val handlerPostProcessors: Iterable<KinesisInboundHandlerPostProcessor> = emptyList()
 ) {
 
     private val log = LoggerFactory.getLogger(this.javaClass)
@@ -15,6 +15,7 @@ class AwsKinesisInboundGateway(
     fun register(handler: KinesisInboundHandler<*, *>) {
 
         val decorated = handlerPostProcessors.fold(handler) { it, postProcessor ->
+            log.debug("Applying post processor <{}> on inbound handler <{}>", postProcessor, it)
             postProcessor.postProcess(it)
         }
         val worker = worker(decorated)

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisInboundHandler.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisInboundHandler.kt
@@ -1,5 +1,8 @@
 package de.bringmeister.spring.aws.kinesis
 
+/**
+ * @see KinesisInboundHandlerPostProcessor
+ */
 interface KinesisInboundHandler<D, M> {
     val stream: String
 
@@ -13,6 +16,12 @@ interface KinesisInboundHandler<D, M> {
      * [UnrecoverableException].
      */
     fun handleRecord(record: Record<D, M>, context: ExecutionContext)
+
+    /**
+     * Called instead of [handleRecord] when deserializing an AWS record into
+     * [Record] failed.
+     */
+    fun handleDeserializationError(cause: Exception, context: ExecutionContext) { }
 
     /** Indicates that the worker is shutting down. */
     fun shutdown() { }
@@ -36,6 +45,7 @@ interface KinesisInboundHandler<D, M> {
         }
     }
 
+    /** Per-execution metadata */
     interface ExecutionContext {
         val isRetry: Boolean
     }

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisInboundHandlerPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisInboundHandlerPostProcessor.kt
@@ -1,5 +1,22 @@
 package de.bringmeister.spring.aws.kinesis
 
+/**
+ * Factory hook that allows for custom modification of new handler instances,
+ * e.g. checking for marker interfaces or decorating them.
+ *
+ * Post processors registered as beans are applied by [AwsKinesisInboundGateway]
+ * to newly created streams, if not noted otherwise.
+ *
+ * Ordering of processors is available using [`@Priority`][javax.annotation.Priority] or
+ * [`@Order`][org.springframework.core.annotation.Order] annotations. Lower values are
+ * applied before higher.  Be aware, that when using a processor to decorate existing
+ * handlers the decorator ordering is reverse to the processor ordering. That is, a processor
+ * applied first (`@Priority(Int.MIN_VALUE)`) will be closest to the initial stream instance,
+ * whereas the one with a high order value (`@Priority(Int.MAX_VALUE)`) is farthest.
+ *
+ * @see KinesisInboundHandler
+ * @see AwsKinesisInboundGateway
+ */
 @FunctionalInterface
 interface KinesisInboundHandlerPostProcessor {
     fun postProcess(handler: KinesisInboundHandler<*, *>): KinesisInboundHandler<*, *>

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisListenerProxy.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisListenerProxy.kt
@@ -15,7 +15,9 @@ data class KinesisListenerProxy(
     init {
         val handleMethod = method
         val parameters = handleMethod.parameters
+        @Suppress("UNCHECKED_CAST")
         this.dataClass = parameters[0].type as Class<Any>
+        @Suppress("UNCHECKED_CAST")
         this.metaClass = parameters[1].type as Class<Any>
     }
 

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisOutboundStream.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisOutboundStream.kt
@@ -1,5 +1,9 @@
 package de.bringmeister.spring.aws.kinesis
 
+/**
+ * @see KinesisOutboundStreamPostProcessor
+ * @see KinesisOutboundStreamFactory
+ */
 interface KinesisOutboundStream {
     val stream: String
     fun send(vararg records: Record<*, *>)

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisOutboundStreamFactory.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisOutboundStreamFactory.kt
@@ -1,5 +1,13 @@
 package de.bringmeister.spring.aws.kinesis
 
+/**
+ * Factory for creating streams.
+ *
+ * Factories are required to apply registered [post processors][KinesisOutboundStreamPostProcessor]
+ * to newly created streams or note, if done otherwise.
+ *
+ * @see KinesisOutboundStream
+ */
 interface KinesisOutboundStreamFactory {
     fun forStream(streamName: String): KinesisOutboundStream
 }

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisOutboundStreamPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/KinesisOutboundStreamPostProcessor.kt
@@ -1,5 +1,23 @@
 package de.bringmeister.spring.aws.kinesis
 
+/**
+ * Factory hook that allows for custom modification of new stream instances,
+ * e.g. checking for marker interfaces or decorating them.
+ *
+ * Post processors registered as beans are applied by [KinesisOutboundStreamFactory]
+ * to newly created streams, if not noted otherwise.
+ *
+ * Ordering of processors is available using [`@Priority`][javax.annotation.Priority] or
+ * [`@Order`][org.springframework.core.annotation.Order] annotations. Lower values are
+ * applied before higher. Be aware, that when using a processor to decorate existing
+ * streams the decorator ordering is inverse to the processor ordering. That is, a processor
+ * applied first (`@Priority(Int.MIN_VALUE)`) will be closest to the initial stream instance,
+ * whereas the one with a high order value (`@Priority(Int.MAX_VALUE)`) is farthest.
+ *
+ * @see KinesisOutboundStream
+ * @see KinesisOutboundStreamFactory
+ * @see AwsKinesisOutboundGateway
+ */
 @FunctionalInterface
 interface KinesisOutboundStreamPostProcessor {
     fun postProcess(stream: KinesisOutboundStream): KinesisOutboundStream

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/creation/CreateStreamPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/creation/CreateStreamPostProcessor.kt
@@ -5,10 +5,16 @@ import de.bringmeister.spring.aws.kinesis.KinesisInboundHandlerPostProcessor
 import de.bringmeister.spring.aws.kinesis.KinesisOutboundStream
 import de.bringmeister.spring.aws.kinesis.KinesisOutboundStreamPostProcessor
 import de.bringmeister.spring.aws.kinesis.StreamInitializer
+import javax.annotation.Priority
 
+@Priority(CreateStreamPostProcessor.priority)
 class CreateStreamPostProcessor(
     private val streamInitializer: StreamInitializer
 ) : KinesisInboundHandlerPostProcessor, KinesisOutboundStreamPostProcessor {
+
+    companion object {
+        const val priority = Int.MIN_VALUE
+    }
 
     override fun postProcess(handler: KinesisInboundHandler<*, *>): KinesisInboundHandler<*, *> {
         streamInitializer.createStreamIfMissing(streamName = handler.stream)

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/creation/KinesisCreateStreamAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/creation/KinesisCreateStreamAutoConfiguration.kt
@@ -10,10 +10,9 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConditionalOnProperty("aws.kinesis.create-streams")
 @AutoConfigureBefore(AwsKinesisAutoConfiguration::class)
-class KinesisCreateStreamAutoConfiguration(
-    private val streamInitializer: StreamInitializer
-) {
+class KinesisCreateStreamAutoConfiguration {
 
     @Bean
-    fun createStreamPostProcessor() = CreateStreamPostProcessor(streamInitializer)
+    fun createStreamPostProcessor(streamInitializer: StreamInitializer) =
+        CreateStreamPostProcessor(streamInitializer)
 }

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/DefaultKinesisTagsProvider.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/DefaultKinesisTagsProvider.kt
@@ -1,0 +1,47 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.Record
+import io.micrometer.core.instrument.Tag
+
+open class DefaultKinesisTagsProvider : KinesisTagsProvider {
+
+    companion object {
+        private val EXCEPTION_NONE = Tag.of("exception", "None")
+        private val RETRY_TRUE = Tag.of("retry", "true")
+        private val RETRY_FALSE = Tag.of("retry", "false")
+
+        fun exception(exception: Throwable?): Tag {
+            if (exception != null) {
+                val simpleName = exception.javaClass.simpleName
+                val tagValue = when (simpleName.isNotBlank()) {
+                    true -> simpleName
+                    false -> exception.javaClass.name
+                }
+                return Tag.of("exception", tagValue)
+            }
+            return EXCEPTION_NONE
+        }
+
+        fun retry(retry: Boolean): Tag =
+            when (retry) {
+                true -> RETRY_TRUE
+                false -> RETRY_FALSE
+            }
+
+        fun stream(stream: String): Tag = Tag.of("stream", stream)
+    }
+
+    override fun inboundTags(
+        stream: String,
+        record: Record<*, *>?,
+        context: KinesisInboundHandler.ExecutionContext,
+        cause: Throwable?
+    ) = listOf(stream(stream), retry(context.isRetry), exception(cause))
+
+    override fun outboundTags(
+        stream: String,
+        records: Array<out Record<*, *>>,
+        cause: Throwable?
+    ) = listOf(stream(stream), exception(cause))
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/KinesisMetricsAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/KinesisMetricsAutoConfiguration.kt
@@ -1,0 +1,27 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.AwsKinesisAutoConfiguration
+import io.micrometer.core.annotation.Timed
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnClass(Timed::class)
+@ConditionalOnProperty("aws.kinesis.metrics", matchIfMissing = true)
+@AutoConfigureBefore(AwsKinesisAutoConfiguration::class)
+@AutoConfigureAfter(MetricsAutoConfiguration::class, CompositeMeterRegistryAutoConfiguration::class)
+class KinesisMetricsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(MeterRegistry::class)
+    fun kinesisMetricsPostProcessor(registry: MeterRegistry) =
+        MetricsPostProcessor(registry)
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/KinesisTagsProvider.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/KinesisTagsProvider.kt
@@ -1,0 +1,20 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.Record
+import io.micrometer.core.instrument.Tag
+
+interface KinesisTagsProvider {
+    fun inboundTags(
+        stream: String,
+        record: Record<*, *>?,
+        context: KinesisInboundHandler.ExecutionContext,
+        cause: Throwable?
+    ): Iterable<Tag>
+
+    fun outboundTags(
+        stream: String,
+        records: Array<out Record<*, *>>,
+        cause: Throwable?
+    ): Iterable<Tag>
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsInboundHandler.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsInboundHandler.kt
@@ -1,0 +1,51 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.Record
+import io.micrometer.core.instrument.MeterRegistry
+
+class MetricsInboundHandler<D, M>(
+    private val delegate: KinesisInboundHandler<D, M>,
+    private val registry: MeterRegistry,
+    private val tagsProvider: KinesisTagsProvider = DefaultKinesisTagsProvider()
+) : KinesisInboundHandler<D, M> by delegate {
+
+    companion object {
+        private const val metricNameTime = "aws.kinesis.starter.inbound.time"
+        private const val metricNameCount = "aws.kinesis.starter.inbound.count"
+    }
+
+    override fun handleRecord(record: Record<D, M>, context: KinesisInboundHandler.ExecutionContext) {
+        try {
+            timedHandleRecord(record, context)
+            success(record, context)
+        } catch (ex: Throwable) {
+            error(record, context, ex)
+            throw ex
+        }
+    }
+
+    override fun handleDeserializationError(cause: Exception, context: KinesisInboundHandler.ExecutionContext) {
+        error(null, context, cause)
+        delegate.handleDeserializationError(cause, context)
+    }
+
+
+    private fun timedHandleRecord(record: Record<D, M>, context: KinesisInboundHandler.ExecutionContext) {
+        val tags = tagsProvider.inboundTags(stream, record, context, null)
+        registry.timer(metricNameTime, tags)
+            .record { delegate.handleRecord(record, context) }
+    }
+
+    private fun success(record: Record<*, *>, context: KinesisInboundHandler.ExecutionContext) {
+        val tags = tagsProvider.inboundTags(stream, record, context, null)
+        registry.counter(metricNameCount, tags)
+            .increment()
+    }
+
+    private fun error(record: Record<*, *>?, context: KinesisInboundHandler.ExecutionContext, cause: Throwable) {
+        val tags = tagsProvider.inboundTags(stream, record, context, cause)
+        registry.counter(metricNameCount, tags)
+            .increment()
+    }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStream.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStream.kt
@@ -1,0 +1,45 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.KinesisOutboundStream
+import de.bringmeister.spring.aws.kinesis.Record
+import io.micrometer.core.instrument.MeterRegistry
+
+class MetricsOutboundStream(
+    private val delegate: KinesisOutboundStream,
+    private val registry: MeterRegistry,
+    private val tagsProvider: KinesisTagsProvider = DefaultKinesisTagsProvider()
+) : KinesisOutboundStream by delegate {
+
+    companion object {
+        private const val metricNameTime = "aws.kinesis.starter.outbound.time"
+        private const val metricNameCount = "aws.kinesis.starter.outbound.count"
+    }
+
+    override fun send(vararg records: Record<*, *>) {
+        try {
+            timedSend(records)
+            success(records)
+        } catch (ex: Throwable) {
+            error(records, ex)
+            throw ex
+        }
+    }
+
+    private fun timedSend(records: Array<out Record<*, *>>) {
+        val tags = tagsProvider.outboundTags(stream, records, null)
+        registry.timer(metricNameTime, tags)
+            .record { delegate.send(*records) }
+    }
+
+    private fun success(records: Array<out Record<*, *>>) {
+        val tags = tagsProvider.outboundTags(stream, records, null)
+        registry.counter(metricNameCount, tags)
+            .increment()
+    }
+
+    private fun error(records: Array<out Record<*, *>>, cause: Throwable) {
+        val tags = tagsProvider.outboundTags(stream, records, cause)
+        registry.counter(metricNameCount, tags)
+            .increment()
+    }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStream.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStream.kt
@@ -3,6 +3,7 @@ package de.bringmeister.spring.aws.kinesis.metrics
 import de.bringmeister.spring.aws.kinesis.KinesisOutboundStream
 import de.bringmeister.spring.aws.kinesis.Record
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 
 class MetricsOutboundStream(
     private val delegate: KinesisOutboundStream,
@@ -11,35 +12,22 @@ class MetricsOutboundStream(
 ) : KinesisOutboundStream by delegate {
 
     companion object {
-        private const val metricNameTime = "aws.kinesis.starter.outbound.time"
-        private const val metricNameCount = "aws.kinesis.starter.outbound.count"
+        private const val metricName = "aws.kinesis.starter.outbound"
     }
 
     override fun send(vararg records: Record<*, *>) {
+        val sample = Timer.start(registry)
         try {
-            timedSend(records)
-            success(records)
+            delegate.send(*records)
+            record(sample, records, null)
         } catch (ex: Throwable) {
-            error(records, ex)
+            record(sample, records, ex)
             throw ex
         }
     }
 
-    private fun timedSend(records: Array<out Record<*, *>>) {
-        val tags = tagsProvider.outboundTags(stream, records, null)
-        registry.timer(metricNameTime, tags)
-            .record { delegate.send(*records) }
-    }
-
-    private fun success(records: Array<out Record<*, *>>) {
-        val tags = tagsProvider.outboundTags(stream, records, null)
-        registry.counter(metricNameCount, tags)
-            .increment()
-    }
-
-    private fun error(records: Array<out Record<*, *>>, cause: Throwable) {
+    private fun record(sample: Timer.Sample, records: Array<out Record<*, *>>, cause: Throwable?) {
         val tags = tagsProvider.outboundTags(stream, records, cause)
-        registry.counter(metricNameCount, tags)
-            .increment()
+        sample.stop(registry.timer(metricName, tags))
     }
 }

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsPostProcessor.kt
@@ -1,0 +1,22 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandlerPostProcessor
+import de.bringmeister.spring.aws.kinesis.KinesisOutboundStream
+import de.bringmeister.spring.aws.kinesis.KinesisOutboundStreamPostProcessor
+import io.micrometer.core.instrument.MeterRegistry
+import javax.annotation.Priority
+
+@Priority(MetricsPostProcessor.priority)
+class MetricsPostProcessor(
+    private val registry: MeterRegistry
+) : KinesisOutboundStreamPostProcessor, KinesisInboundHandlerPostProcessor {
+
+    companion object {
+        const val priority = 1000
+    }
+
+    override fun postProcess(handler: KinesisInboundHandler<*, *>) = MetricsInboundHandler(handler, registry)
+
+    override fun postProcess(stream: KinesisOutboundStream) = MetricsOutboundStream(stream, registry)
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/validation/KinesisValidationAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/validation/KinesisValidationAutoConfiguration.kt
@@ -15,10 +15,9 @@ import javax.validation.Validator
 @ConditionalOnBean(Validator::class)
 @ConditionalOnProperty("aws.kinesis.validate", matchIfMissing = true)
 @AutoConfigureBefore(AwsKinesisAutoConfiguration::class)
-class KinesisValidationAutoConfiguration(
-    private val validator: Validator
-) {
+class KinesisValidationAutoConfiguration {
 
     @Bean
-    fun validatingPostProcessor() = ValidatingPostProcessor(validator)
+    fun validatingPostProcessor(validator: Validator) =
+        ValidatingPostProcessor(validator)
 }

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/validation/ValidatingPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/validation/ValidatingPostProcessor.kt
@@ -4,11 +4,17 @@ import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
 import de.bringmeister.spring.aws.kinesis.KinesisInboundHandlerPostProcessor
 import de.bringmeister.spring.aws.kinesis.KinesisOutboundStream
 import de.bringmeister.spring.aws.kinesis.KinesisOutboundStreamPostProcessor
+import javax.annotation.Priority
 import javax.validation.Validator
 
+@Priority(ValidatingPostProcessor.priority)
 class ValidatingPostProcessor(
     private val validator: Validator
 ) : KinesisInboundHandlerPostProcessor, KinesisOutboundStreamPostProcessor {
+
+    companion object {
+        const val priority = -1000
+    }
 
     override fun postProcess(handler: KinesisInboundHandler<*, *>) =
         ValidatingInboundHandler(handler, validator)

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=de.bringmeister.spring.aws.kinesis.AwsKinesisAutoConfiguration,\
 de.bringmeister.spring.aws.kinesis.KinesisLocalConfiguration, \
 de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration, \
-de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration
+de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration, \
+de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/KinesisInboundHandlerTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/KinesisInboundHandlerTest.kt
@@ -29,6 +29,14 @@ class KinesisInboundHandlerTest {
     }
 
     @Test
+    fun `should not throw on handleDeserializationError`() {
+        val cause = RuntimeException("expected")
+        val context = TestKinesisInboundHandler.TestExecutionContext()
+        assertThatCode { handler.handleDeserializationError(cause, context) }
+            .doesNotThrowAnyException()
+    }
+
+    @Test
     fun `should wrap any exception in UnrecoverableException`() {
 
         val ex = MyException()

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/PostProcessorIntegrationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/PostProcessorIntegrationTest.kt
@@ -1,0 +1,100 @@
+package de.bringmeister.spring.aws.kinesis
+
+import com.nhaarman.mockito_kotlin.mock
+import de.bringmeister.spring.aws.kinesis.creation.CreateStreamPostProcessor
+import de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration
+import de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration
+import de.bringmeister.spring.aws.kinesis.metrics.MetricsPostProcessor
+import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration
+import de.bringmeister.spring.aws.kinesis.validation.ValidatingPostProcessor
+import io.micrometer.core.instrument.MeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringRunner
+import javax.validation.Validator
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = [
+        PostProcessorIntegrationTest.TestConfiguration::class,
+        KinesisValidationAutoConfiguration::class,
+        KinesisCreateStreamAutoConfiguration::class,
+        KinesisMetricsAutoConfiguration::class
+    ],
+    properties = [
+        "aws.kinesis.create-streams: true",
+        "aws.kinesis.validate: true",
+        "aws.kinesis.metrics: true"
+    ]
+)
+@ActiveProfiles("test")
+class PostProcessorIntegrationTest {
+
+    @Autowired
+    private lateinit var inboundPostProcessors: List<KinesisInboundHandlerPostProcessor>
+
+    @Autowired
+    private lateinit var outboundPostProcessors: List<KinesisOutboundStreamPostProcessor>
+
+    @Test
+    fun `should order inbound post processors by priority`() {
+        assertThat(inboundPostProcessors)
+            .hasAtLeastOneElementOfType(CreateStreamPostProcessor::class.java)
+            .hasAtLeastOneElementOfType(ValidatingPostProcessor::class.java)
+            .hasAtLeastOneElementOfType(MetricsPostProcessor::class.java)
+            .hasSize(3)
+        val postProcessorsTypes = inboundPostProcessors.map { it::class }
+        assertThat(postProcessorsTypes)
+            .containsExactly(
+                // We want to create streams first, because when this fails the rest is pointless.
+                // After this, we want delegates to be ordered as follows:
+                // * metrics
+                // * validation
+                // * target
+                // Since processors are applied in given order delegation happens in inverse order.
+                CreateStreamPostProcessor::class,
+                ValidatingPostProcessor::class,
+                MetricsPostProcessor::class
+            )
+    }
+
+    @Test
+    fun `should order outbound post processors by priority`() {
+        assertThat(outboundPostProcessors)
+            .hasAtLeastOneElementOfType(CreateStreamPostProcessor::class.java)
+            .hasAtLeastOneElementOfType(ValidatingPostProcessor::class.java)
+            .hasAtLeastOneElementOfType(MetricsPostProcessor::class.java)
+            .hasSize(3)
+        val postProcessorsTypes = outboundPostProcessors.map { it::class }
+        assertThat(postProcessorsTypes)
+            .containsExactly(
+                // We want to create streams first, because when this fails the rest is pointless.
+                // After this, we want delegates to be ordered as follows:
+                // * metrics
+                // * validation
+                // * target
+                // Since processors are applied in given order delegation happens in inverse order.
+                CreateStreamPostProcessor::class,
+                ValidatingPostProcessor::class,
+                MetricsPostProcessor::class
+            )
+    }
+
+    @org.springframework.boot.test.context.TestConfiguration
+    internal class TestConfiguration {
+        @Bean
+        fun meterRegistry() = mock<MeterRegistry> { }
+
+        @Bean
+        fun validator() = mock<Validator> { }
+
+        @Bean
+        fun streamInitializer() = mock<StreamInitializer> { }
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/DefaultKinesisTagsProviderTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/DefaultKinesisTagsProviderTest.kt
@@ -1,0 +1,82 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.Record
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import io.micrometer.core.instrument.Tag
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class DefaultKinesisTagsProviderTest {
+
+    private val streamName = "test-stream"
+    private val tagsProvider = DefaultKinesisTagsProvider()
+    private val record = Record(Any(), Any())
+
+    @Test
+    fun `should provide tags for inbound metrics (retry = false, cause = null)`() {
+
+        val context = TestKinesisInboundHandler.TestExecutionContext(
+            isRetry = false
+        )
+        val tags = tagsProvider.inboundTags(streamName, record, context, null)
+        assertTags(tags, withRetry = true)
+    }
+
+    @Test
+    fun `should provide tags for inbound metrics (retry = true, cause = null)`() {
+
+        val context = TestKinesisInboundHandler.TestExecutionContext(
+            isRetry = true
+        )
+        val tags = tagsProvider.inboundTags(streamName, record, context, null)
+        assertTags(tags, withRetry = true)
+    }
+
+    @Test
+    fun `should provide tags for inbound metrics (retry = false, cause = MyException)`() {
+
+        val context = TestKinesisInboundHandler.TestExecutionContext(
+            isRetry = false
+        )
+        val tags = tagsProvider.inboundTags(streamName, record, context, MyException)
+        assertTags(tags, withRetry = true, cause = MyException)
+    }
+
+    @Test
+    fun `should provide tags for inbound metrics (retry = true, cause = MyException)`() {
+
+        val context = TestKinesisInboundHandler.TestExecutionContext(
+            isRetry = true
+        )
+        val tags = tagsProvider.inboundTags(streamName, record, context, MyException)
+        assertTags(tags, withRetry = true, cause = MyException)
+    }
+
+    @Test
+    fun `should provide tags for outbound metrics (cause = null)`() {
+
+        val tags = tagsProvider.outboundTags(streamName, arrayOf(record), null)
+        assertTags(tags)
+    }
+
+    @Test
+    fun `should provide tags for outbound metrics (cause = MyException)`() {
+
+        val tags = tagsProvider.outboundTags(streamName, arrayOf(record), MyException)
+        assertTags(tags, cause = MyException)
+    }
+
+    private fun assertTags(tags: Iterable<Tag>, withRetry: Boolean = false, cause: Throwable? = null) {
+        assertThat(tags)
+            .anyMatch { it.key == "stream" && it.value == streamName }
+            .anyMatch { it.key == "exception" &&
+                when (cause) {
+                    null -> it.value == "None"
+                    else -> it.value == cause::class.simpleName ?: cause::class.java.name
+                }
+            }
+            .anyMatch { !withRetry || (it.key == "retry" && it.value.matches("true|false".toRegex())) }
+    }
+
+    private object MyException : Exception()
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsInboundHandlerTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsInboundHandlerTest.kt
@@ -35,7 +35,7 @@ class MetricsInboundHandlerTest {
         handler.handleRecord(record, context)
 
         assertThat(registry.meters.map { it.id })
-            .anyMatch { it.name == "aws.kinesis.starter.inbound.time" && tags == Tags.of(it.tags) }
+            .anyMatch { it.name == "aws.kinesis.starter.inbound" && tags == Tags.of(it.tags) }
     }
 
     @Test
@@ -47,7 +47,7 @@ class MetricsInboundHandlerTest {
         handler.handleRecord(record, context)
 
         assertThat(registry.meters.map { it.id })
-            .anyMatch { it.name == "aws.kinesis.starter.inbound.count" && tags == Tags.of(it.tags) }
+            .anyMatch { it.name == "aws.kinesis.starter.inbound" && tags == Tags.of(it.tags) }
     }
 
     @Test
@@ -61,7 +61,7 @@ class MetricsInboundHandlerTest {
             .isSameAs(MyException)
 
         assertThat(registry.meters.map { it.id })
-            .anyMatch { it.name == "aws.kinesis.starter.inbound.count" && tags == Tags.of(it.tags) }
+            .anyMatch { it.name == "aws.kinesis.starter.inbound" && tags == Tags.of(it.tags) }
     }
 
     @Test
@@ -76,7 +76,7 @@ class MetricsInboundHandlerTest {
             .isSameAs(delegateException)
 
         assertThat(registry.meters.map { it.id })
-            .anyMatch { it.name == "aws.kinesis.starter.inbound.count" && tags == Tags.of(it.tags) }
+            .anyMatch { it.name == "aws.kinesis.starter.inbound" && tags == Tags.of(it.tags) }
     }
 
     @Test

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsInboundHandlerTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsInboundHandlerTest.kt
@@ -1,0 +1,89 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.doThrow
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.Record
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.Test
+
+class MetricsInboundHandlerTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val mockDelegate = mock<KinesisInboundHandler<Any, Any>> {
+        on { stream } doReturn "test"
+    }
+    private val mockTagsProvider = mock<KinesisTagsProvider> { }
+    private val handler = MetricsInboundHandler(mockDelegate, registry, mockTagsProvider)
+
+    private val record = Record(Any(), Any())
+    private val context = TestKinesisInboundHandler.TestExecutionContext()
+
+    @Test
+    fun `should time calls to delegate`() {
+
+        val tags = Tags.of("test", "should time calls to delegate")
+        whenever(mockTagsProvider.inboundTags("test", record, context, null)).thenReturn(tags)
+
+        handler.handleRecord(record, context)
+
+        assertThat(registry.meters.map { it.id })
+            .anyMatch { it.name == "aws.kinesis.starter.inbound.time" && tags == Tags.of(it.tags) }
+    }
+
+    @Test
+    fun `should count successful calls to delegate`() {
+
+        val tags = Tags.of("test", "should count successful calls to delegate")
+        whenever(mockTagsProvider.inboundTags("test", record, context, null)).thenReturn(tags)
+
+        handler.handleRecord(record, context)
+
+        assertThat(registry.meters.map { it.id })
+            .anyMatch { it.name == "aws.kinesis.starter.inbound.count" && tags == Tags.of(it.tags) }
+    }
+
+    @Test
+    fun `should count failed calls to delegate and bubble exception`() {
+
+        val tags = Tags.of("test", "should count failed calls to delegate and bubble exception")
+        whenever(mockTagsProvider.inboundTags("test", record, context, MyException)).thenReturn(tags)
+        whenever(mockDelegate.handleRecord(record, context)).doThrow(MyException)
+
+        assertThatCode { handler.handleRecord(record, context) }
+            .isSameAs(MyException)
+
+        assertThat(registry.meters.map { it.id })
+            .anyMatch { it.name == "aws.kinesis.starter.inbound.count" && tags == Tags.of(it.tags) }
+    }
+
+    @Test
+    fun `should count deserialization failures, call delegate and bubble exceptions`() {
+
+        val tags = Tags.of("test", "should count deserialization failures, call delegate and bubble exceptions")
+        val delegateException = RuntimeException("expected")
+        whenever(mockTagsProvider.inboundTags("test", null, context, MyException)).thenReturn(tags)
+        whenever(mockDelegate.handleDeserializationError(MyException, context)).doThrow(delegateException)
+
+        assertThatCode { handler.handleDeserializationError(MyException, context) }
+            .isSameAs(delegateException)
+
+        assertThat(registry.meters.map { it.id })
+            .anyMatch { it.name == "aws.kinesis.starter.inbound.count" && tags == Tags.of(it.tags) }
+    }
+
+    @Test
+    fun `should invoke delegate`() {
+        handler.handleRecord(record, context)
+        verify(mockDelegate).handleRecord(record, context)
+    }
+
+    private object MyException : RuntimeException()
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStreamTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStreamTest.kt
@@ -33,7 +33,7 @@ class MetricsOutboundStreamTest {
         handler.send(record)
 
         assertThat(registry.meters.map { it.id })
-            .anyMatch { it.name == "aws.kinesis.starter.outbound.time" && tags == Tags.of(it.tags) }
+            .anyMatch { it.name == "aws.kinesis.starter.outbound" && tags == Tags.of(it.tags) }
     }
 
     @Test
@@ -45,7 +45,7 @@ class MetricsOutboundStreamTest {
         handler.send(record)
 
         assertThat(registry.meters.map { it.id })
-            .anyMatch { it.name == "aws.kinesis.starter.outbound.count" && tags == Tags.of(it.tags) }
+            .anyMatch { it.name == "aws.kinesis.starter.outbound" && tags == Tags.of(it.tags) }
     }
 
     @Test
@@ -59,7 +59,7 @@ class MetricsOutboundStreamTest {
             .isSameAs(MyException)
 
         assertThat(registry.meters.map { it.id })
-            .anyMatch { it.name == "aws.kinesis.starter.outbound.count" && tags == Tags.of(it.tags) }
+            .anyMatch { it.name == "aws.kinesis.starter.outbound" && tags == Tags.of(it.tags) }
     }
 
     @Test

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStreamTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsOutboundStreamTest.kt
@@ -1,0 +1,72 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.doThrow
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import de.bringmeister.spring.aws.kinesis.KinesisOutboundStream
+import de.bringmeister.spring.aws.kinesis.Record
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.Test
+
+class MetricsOutboundStreamTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val mockDelegate = mock<KinesisOutboundStream> {
+        on { stream } doReturn "test"
+    }
+    private val mockTagsProvider = mock<KinesisTagsProvider> { }
+    private val handler = MetricsOutboundStream(mockDelegate, registry, mockTagsProvider)
+
+    private val record = Record(Any(), Any())
+
+    @Test
+    fun `should time calls to delegate`() {
+
+        val tags = Tags.of("test", "should time calls to delegate")
+        whenever(mockTagsProvider.outboundTags("test", arrayOf(record), null)).thenReturn(tags)
+
+        handler.send(record)
+
+        assertThat(registry.meters.map { it.id })
+            .anyMatch { it.name == "aws.kinesis.starter.outbound.time" && tags == Tags.of(it.tags) }
+    }
+
+    @Test
+    fun `should count successful calls to delegate`() {
+
+        val tags = Tags.of("test", "should count successful calls to delegate")
+        whenever(mockTagsProvider.outboundTags("test", arrayOf(record), null)).thenReturn(tags)
+
+        handler.send(record)
+
+        assertThat(registry.meters.map { it.id })
+            .anyMatch { it.name == "aws.kinesis.starter.outbound.count" && tags == Tags.of(it.tags) }
+    }
+
+    @Test
+    fun `should count failed calls to delegate and bubble exception`() {
+
+        val tags = Tags.of("test", "should count failed calls to delegate and bubble exception")
+        whenever(mockTagsProvider.outboundTags("test", arrayOf(record), MyException)).thenReturn(tags)
+        whenever(mockDelegate.send(record)).doThrow(MyException)
+
+        assertThatCode { handler.send(record) }
+            .isSameAs(MyException)
+
+        assertThat(registry.meters.map { it.id })
+            .anyMatch { it.name == "aws.kinesis.starter.outbound.count" && tags == Tags.of(it.tags) }
+    }
+
+    @Test
+    fun `should invoke delegate listener`() {
+        handler.send(record, record)
+        verify(mockDelegate).send(record, record)
+    }
+
+    private object MyException : RuntimeException()
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsPostProcessorTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/MetricsPostProcessorTest.kt
@@ -1,0 +1,31 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.TestKinesisOutboundStream
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class MetricsPostProcessorTest {
+
+    private val meterRegistry = SimpleMeterRegistry()
+    private val processor = MetricsPostProcessor(meterRegistry)
+
+    @Test
+    fun `should decorate handler with metrics wrapper`() {
+        val handler = TestKinesisInboundHandler()
+        val decorated = processor.postProcess(handler)
+
+        assertThat(decorated).isInstanceOf(MetricsInboundHandler::class.java)
+        assertThat(decorated.stream).isSameAs(handler.stream)
+    }
+
+    @Test
+    fun `should decorate stream with metrics wrapper`() {
+        val stream = TestKinesisOutboundStream()
+        val decorated = processor.postProcess(stream)
+
+        assertThat(decorated).isInstanceOf(MetricsOutboundStream::class.java)
+        assertThat(decorated.stream).isSameAs(stream.stream)
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/validation/ValidatingInboundHandlerTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/validation/ValidatingInboundHandlerTest.kt
@@ -34,7 +34,7 @@ class ValidatingInboundHandlerTest {
     }
 
     @Test
-    fun `should invoke delegate listener on valid record`() {
+    fun `should invoke delegate on valid record`() {
         whenever(mockValidator.validate(anyVararg<Any>())).thenReturn(emptySet())
         handler.handleRecord(record, context)
         verify(mockDelegate).handleRecord(record, context)

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/validation/ValidatingOutboundStreamTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/validation/ValidatingOutboundStreamTest.kt
@@ -34,7 +34,7 @@ class ValidatingOutboundStreamTest {
     }
 
     @Test
-    fun `should invoke delegate listener on valid record`() {
+    fun `should invoke delegate on valid record`() {
         whenever(mockValidator.validate(anyVararg<Any>())).thenReturn(emptySet())
         handler.send(record)
         verify(mockDelegate).send(argWhere { it == record })


### PR DESCRIPTION
Implement put/get metrics controlled by setting `aws.kinesis.metrics`

Notable changes:
* Defer loading of post processors until first use in order to avoid bootstrapping order issues. (needed until https://github.com/spring-projects/spring-boot/issues/15483 or https://github.com/micrometer-metrics/micrometer/pull/1157 are fixed)
* Adds a hook to react on deserialization failures and reports metrics on them.
* Adds priorities to post processors and test their setup in `PostProcessorIntegrationTest`.
* Add JavaDoc to relevant API hooks (Handler + Stream and respective post processors)