### PR TITLE
Allow applying additional worker specifics

### DIFF
--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisAutoConfiguration.kt
@@ -26,7 +26,7 @@ class AwsKinesisAutoConfiguration {
         kinesisSettings: AwsKinesisSettings
     ): ClientConfigFactory {
 
-        return ClientConfigFactory(credentialsProvider, awsCredentialsProviderFactory, kinesisSettings)
+        return DefaultClientConfigFactory(credentialsProvider, awsCredentialsProviderFactory, kinesisSettings)
     }
 
     @Bean

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/ClientConfigFactory.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/ClientConfigFactory.kt
@@ -1,37 +1,7 @@
 package de.bringmeister.spring.aws.kinesis
 
-import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
-import java.net.InetAddress
-import java.util.UUID
 
-class ClientConfigFactory(
-    private val credentialsProvider: AWSCredentialsProvider,
-    private val awsCredentialsProviderFactory: AWSCredentialsProviderFactory,
-    private val kinesisSettings: AwsKinesisSettings
-) {
-
-    fun consumerConfig(streamName: String): KinesisClientLibConfiguration {
-
-        val consumerSettings = kinesisSettings.getConsumerSettingsOrDefault(streamName)
-        val roleToAssume = "arn:aws:iam::${consumerSettings.awsAccountId}:role/${consumerSettings.iamRoleToAssume}"
-        val credentials = awsCredentialsProviderFactory.credentials(roleToAssume)
-        val workerId = InetAddress.getLocalHost().canonicalHostName + ":" + UUID.randomUUID()
-        val applicationName = "${kinesisSettings.consumerGroup}_$streamName"
-
-        return KinesisClientLibConfiguration(
-            applicationName,
-            streamName,
-            credentials,
-            credentialsProvider,
-            credentialsProvider,
-            workerId
-        )
-            .withInitialPositionInStream(kinesisSettings.initialPositionInStream)
-            .withKinesisEndpoint(kinesisSettings.kinesisUrl)
-            .withMetricsLevel(kinesisSettings.metricsLevel)
-            .withDynamoDBEndpoint(kinesisSettings.dynamoDbSettings!!.url)
-            .withInitialLeaseTableReadCapacity(kinesisSettings.dynamoDbSettings!!.leaseTableReadCapacity)
-            .withInitialLeaseTableWriteCapacity(kinesisSettings.dynamoDbSettings!!.leaseTableWriteCapacity)
-    }
+interface ClientConfigFactory {
+    fun consumerConfig(streamName: String): KinesisClientLibConfiguration
 }

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/DefaultClientConfigFactory.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/DefaultClientConfigFactory.kt
@@ -1,0 +1,37 @@
+package de.bringmeister.spring.aws.kinesis
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
+import java.net.InetAddress
+import java.util.UUID
+
+class DefaultClientConfigFactory(
+    private val credentialsProvider: AWSCredentialsProvider,
+    private val awsCredentialsProviderFactory: AWSCredentialsProviderFactory,
+    private val kinesisSettings: AwsKinesisSettings
+) : ClientConfigFactory {
+
+    override fun consumerConfig(streamName: String): KinesisClientLibConfiguration {
+
+        val consumerSettings = kinesisSettings.getConsumerSettingsOrDefault(streamName)
+        val roleToAssume = "arn:aws:iam::${consumerSettings.awsAccountId}:role/${consumerSettings.iamRoleToAssume}"
+        val credentials = awsCredentialsProviderFactory.credentials(roleToAssume)
+        val workerId = InetAddress.getLocalHost().canonicalHostName + ":" + UUID.randomUUID()
+        val applicationName = "${kinesisSettings.consumerGroup}_$streamName"
+
+        return KinesisClientLibConfiguration(
+            applicationName,
+            streamName,
+            credentials,
+            credentialsProvider,
+            credentialsProvider,
+            workerId
+        )
+            .withInitialPositionInStream(kinesisSettings.initialPositionInStream)
+            .withKinesisEndpoint(kinesisSettings.kinesisUrl)
+            .withMetricsLevel(kinesisSettings.metricsLevel)
+            .withDynamoDBEndpoint(kinesisSettings.dynamoDbSettings!!.url)
+            .withInitialLeaseTableReadCapacity(kinesisSettings.dynamoDbSettings!!.leaseTableReadCapacity)
+            .withInitialLeaseTableWriteCapacity(kinesisSettings.dynamoDbSettings!!.leaseTableWriteCapacity)
+    }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/WorkerFactory.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/WorkerFactory.kt
@@ -5,7 +5,7 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.WorkerStateChangeListener
 import org.springframework.context.ApplicationEventPublisher
 
-class WorkerFactory(
+open class WorkerFactory(
     private val clientConfigFactory: ClientConfigFactory,
     private val settings: AwsKinesisSettings,
     private val applicationEventPublisher: ApplicationEventPublisher
@@ -21,8 +21,7 @@ class WorkerFactory(
 
         val config = clientConfigFactory.consumerConfig(handler.stream)
 
-        return Worker
-            .Builder()
+        return workerBuilder()
             .workerStateChangeListener { nextState ->
                 when (nextState) {
                     WorkerStateChangeListener.WorkerState.STARTED -> {
@@ -38,4 +37,6 @@ class WorkerFactory(
             .recordProcessorFactory(processorFactory)
             .build()
     }
+
+    open fun workerBuilder(): Worker.Builder = Worker.Builder()
 }

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/ClientConfigFactoryTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/ClientConfigFactoryTest.kt
@@ -15,7 +15,7 @@ class ClientConfigFactoryTest {
     private val credentialsProvider = mock<AWSCredentialsProvider>()
     private val settings = AwsKinesisSettingsTestFactory.settings().withRequired().withConsumerFor("my-kinesis-stream")
     private val clientConfigFactory =
-        ClientConfigFactory(credentialsProvider, credentialsProviderFactory, settings.build())
+        DefaultClientConfigFactory(credentialsProvider, credentialsProviderFactory, settings.build())
 
     @Before
     fun setUp() {


### PR DESCRIPTION
This change allows to override specifics of the instantiated `Worker` as well as Kinesis consumer configuration without impacting the concepts and workings of this library.

