### PR TITLE
Correct visibility and provide stream name when creating workers

### DIFF
--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/WorkerFactory.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/WorkerFactory.kt
@@ -21,7 +21,7 @@ open class WorkerFactory(
 
         val config = clientConfigFactory.consumerConfig(handler.stream)
 
-        return workerBuilder()
+        return workerBuilder(handler.stream)
             .workerStateChangeListener { nextState ->
                 when (nextState) {
                     WorkerStateChangeListener.WorkerState.STARTED -> {
@@ -38,5 +38,5 @@ open class WorkerFactory(
             .build()
     }
 
-    open fun workerBuilder(): Worker.Builder = Worker.Builder()
+    protected open fun workerBuilder(streamName: String): Worker.Builder = Worker.Builder()
 }


### PR DESCRIPTION
Follow up to #72, where I missed to specify the visibility modifier.