### PR TITLE
Build clients for worker manually

### DIFF
--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/WorkerFactory.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/WorkerFactory.kt
@@ -1,5 +1,9 @@
 package de.bringmeister.spring.aws.kinesis
 
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.WorkerStateChangeListener
@@ -35,6 +39,30 @@ open class WorkerFactory(
             }
             .config(config)
             .recordProcessorFactory(processorFactory)
+            .kinesisClient(
+                AmazonKinesisClientBuilder
+                    .standard()
+                    .withCredentials(config.kinesisCredentialsProvider)
+                    .withClientConfiguration(config.kinesisClientConfiguration)
+                    .withEndpointConfiguration(EndpointConfiguration(config.kinesisEndpoint, settings.region))
+                    .build()
+            )
+            .dynamoDBClient(
+                AmazonDynamoDBClientBuilder
+                    .standard()
+                    .withCredentials(config.dynamoDBCredentialsProvider)
+                    .withClientConfiguration(config.dynamoDBClientConfiguration)
+                    .withEndpointConfiguration(EndpointConfiguration(config.dynamoDBEndpoint, settings.region))
+                    .build()
+            )
+            .cloudWatchClient(
+                AmazonCloudWatchClientBuilder
+                    .standard()
+                    .withCredentials(config.cloudWatchCredentialsProvider)
+                    .withClientConfiguration(config.cloudWatchClientConfiguration)
+                    .withRegion(settings.region)
+                    .build()
+            )
             .build()
     }
 


### PR DESCRIPTION
On every startup of the Kinesis Starter Lib a bunch of warnings are logged (once for each listener): 

```
2019-03-11 18:20:01.703  WARN 99135 --- [           main] c.a.s.k.clientlibrary.lib.worker.Worker  : Received configuration for endpoint as http://localhost:14567, and region as null.
2019-03-11 18:20:01.708  WARN 99135 --- [           main] c.a.s.k.clientlibrary.lib.worker.Worker  : Received configuration for endpoint as http://localhost:14568, and region as null.
2019-03-11 18:20:01.729  WARN 99135 --- [           main] c.a.s.k.clientlibrary.lib.worker.Worker  : No configuration received for endpoint and region, will default region to us-east-1
```

Those warnings are logged in `com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker` when the clients for Kinesis, DynamoDB and CloudWatch are created. I want to avoid warnings as much as possible, although I cannot see anything wrong with this particular code. IMHO those logs should be on info level, not warning. 

Anyway, in order to avoid those warnings, I would propose to create the clients for Kinesis, DynamoDB and CloudWatch manually. 
