### PR TITLE
Allow overriding credentials per role 

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ aws:
         iam-role-to-assume: SpecialKinesisConsumer
 ```
 
+#### Specify credentials per role
+
+AWS credentials are resolved using AWS' `DefaultAWSCredentialsProviderChain`.
+It is possible to override credentials on a per-role basis as follows:
+
+```yaml
+aws:
+  kinesis:
+    role-credentials:
+      - iam-role-to-asssume: <IAM_ROLE>
+        aws-account-id: <ACCOUNT_ID>
+        access-key: "xxx"
+        secret-key: "yyy"
+      - ...
+```
+
 #### Disable automatic registration of `@KinesisListener`
 
 Automatic registration of `@KinesisListener`-annotated methods can be disabled.
@@ -190,7 +206,7 @@ Automatic registration of `@KinesisListener`-annotated methods can be disabled.
 aws:
   kinesis:
     listener:
-        disabled: true
+      disabled: true
 ```
 
 ## Usage

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettings.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettings.kt
@@ -5,6 +5,7 @@ import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.validation.annotation.Validated
 import java.util.concurrent.TimeUnit
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 
 @Validated
@@ -45,6 +46,7 @@ class AwsKinesisSettings {
     var creationTimeoutInMilliSeconds = TimeUnit.SECONDS.toMillis(30)
     var consumer: MutableList<StreamSettings> = mutableListOf()
     var producer: MutableList<StreamSettings> = mutableListOf()
+    var roleCredentials: MutableList<RoleCredentials> = mutableListOf()
 
     fun getConsumerSettingsOrDefault(stream: String): StreamSettings {
         return consumer.firstOrNull { it.streamName == stream } ?: return defaultSettingsFor(stream)
@@ -61,6 +63,9 @@ class AwsKinesisSettings {
         defaultSettings.iamRoleToAssume = iamRoleToAssume
         return defaultSettings
     }
+
+    fun getRoleCredentials(roleToAssume: String) =
+        roleCredentials.find { roleToAssume == it.roleArn() }
 }
 
 class RetrySettings {
@@ -92,4 +97,20 @@ class StreamSettings {
 
     @NotNull
     lateinit var iamRoleToAssume: String
+}
+
+class RoleCredentials {
+    @NotBlank
+    lateinit var awsAccountId: String
+
+    @NotBlank
+    lateinit var iamRoleToAssume: String
+
+    @NotBlank
+    lateinit var accessKey: String
+
+    @NotBlank
+    lateinit var secretKey: String
+
+    fun roleArn() = "arn:aws:iam::$awsAccountId:role/$iamRoleToAssume"
 }

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/STSAssumeRoleSessionCredentialsProviderFactory.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/STSAssumeRoleSessionCredentialsProviderFactory.kt
@@ -1,8 +1,11 @@
 package de.bringmeister.spring.aws.kinesis
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class STSAssumeRoleSessionCredentialsProviderFactory(
@@ -10,14 +13,28 @@ class STSAssumeRoleSessionCredentialsProviderFactory(
     private val settings: AwsKinesisSettings
 ) : AWSCredentialsProviderFactory {
 
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun credentials(roleToAssume: String): AWSCredentialsProvider {
+        val streamCredentialsProvider = when (val credentials = settings.getRoleCredentials(roleToAssume)) {
+            null -> {
+                log.debug(
+                    "Using application-configured credentials provider <{}> to assume role <{}>.",
+                    credentialsProvider::class.simpleName, roleToAssume)
+                credentialsProvider
+            }
+            else -> {
+                log.debug("Using static configuration-provided credentials to assume role <{}>.", roleToAssume)
+                AWSStaticCredentialsProvider(BasicAWSCredentials(credentials.accessKey, credentials.secretKey))
+            }
+        }
         return STSAssumeRoleSessionCredentialsProvider
             .Builder(roleToAssume, UUID.randomUUID().toString())
             .withStsClient(
                 AWSSecurityTokenServiceClientBuilder
                     .standard()
                     .withRegion(settings.region)
-                    .withCredentials(credentialsProvider)
+                    .withCredentials(streamCredentialsProvider)
                     .build()
             )
             .build()

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/STSAssumeRoleSessionCredentialsProviderFactoryTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/STSAssumeRoleSessionCredentialsProviderFactoryTest.kt
@@ -5,6 +5,7 @@ import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -32,5 +33,22 @@ class STSAssumeRoleSessionCredentialsProviderFactoryTest {
         unit.credentials("anyRole")
 
         verify(settings).region
+    }
+
+    @Test
+    fun `should use credentials when set`() {
+
+        val credentials = RoleCredentials().apply {
+            accessKey = "access"
+            secretKey = "secret"
+        }
+        whenever(settings.getRoleCredentials("roleWithCredentials")).thenReturn(credentials)
+
+        val unit = STSAssumeRoleSessionCredentialsProviderFactory(credentialsProvider, settings)
+
+        unit.credentials("roleWithCredentials")
+
+        // it's not really possible to test the credentials, since they are thrown against a token service
+        verify(settings).getRoleCredentials("roleWithCredentials")
     }
 }


### PR DESCRIPTION
By setting the property `aws.kinesis.role-credentials` it is possible to specify credentials for each role separate.