### PR TITLE
Include `RetryableAutoConfiguration` in Spring's factory list

### DIFF
--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/retry/RetryableRecordHandlerAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/retry/RetryableRecordHandlerAutoConfiguration.kt
@@ -1,6 +1,8 @@
 package de.bringmeister.spring.aws.kinesis.retry
 
+import de.bringmeister.spring.aws.kinesis.AwsKinesisAutoConfiguration
 import de.bringmeister.spring.aws.kinesis.RetrySettings
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -11,6 +13,7 @@ import javax.validation.constraints.Min
 
 @Configuration
 @EnableConfigurationProperties(RetryableRecordProcessorSettings::class)
+@AutoConfigureBefore(AwsKinesisAutoConfiguration::class)
 class RetryableRecordHandlerAutoConfiguration {
 
     @Bean

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -2,4 +2,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=de.bringmeister.s
 de.bringmeister.spring.aws.kinesis.KinesisLocalConfiguration, \
 de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration, \
 de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration, \
-de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration
+de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration, \
+de.bringmeister.spring.aws.kinesis.retry.RetryableRecordHandlerAutoConfiguration

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/creation/KinesisCreateStreamAutoConfigurationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/creation/KinesisCreateStreamAutoConfigurationTest.kt
@@ -1,0 +1,40 @@
+package de.bringmeister.spring.aws.kinesis.creation
+
+import com.nhaarman.mockito_kotlin.mock
+import de.bringmeister.spring.aws.kinesis.StreamInitializer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+
+class KinesisCreateStreamAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(KinesisCreateStreamAutoConfiguration::class.java))
+        .withUserConfiguration(MockStreamInitializerConfiguration::class.java)
+
+    @Test
+    fun `should not register CreateStreamPostProcessor when not explicitly enabled`() {
+        contextRunner
+            .run {
+                assertThat(it).doesNotHaveBean(CreateStreamPostProcessor::class.java)
+            }
+    }
+
+    @Test
+    fun `should register CreateStreamPostProcessor in context when enabled`() {
+        contextRunner
+            .withPropertyValues("aws.kinesis.create-streams: true")
+            .run {
+                assertThat(it).hasSingleBean(CreateStreamPostProcessor::class.java)
+            }
+    }
+
+    @TestConfiguration
+    private class MockStreamInitializerConfiguration {
+        @Bean
+        fun streamInitializer() = mock<StreamInitializer>()
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/KinesisMetricsAutoConfigurationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/metrics/KinesisMetricsAutoConfigurationTest.kt
@@ -1,0 +1,45 @@
+package de.bringmeister.spring.aws.kinesis.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class KinesisMetricsAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(KinesisMetricsAutoConfiguration::class.java))
+
+    @Test
+    fun `should not register MetricsPostProcessor when disabled`() {
+        contextRunner
+            .withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration::class.java, CompositeMeterRegistryAutoConfiguration::class.java))
+            .withPropertyValues("aws.kinesis.metrics: false")
+            .run {
+                assertThat(it).hasSingleBean(MeterRegistry::class.java)
+                assertThat(it).doesNotHaveBean(MetricsPostProcessor::class.java)
+            }
+    }
+
+    @Test
+    fun `should not register MetricsPostProcessor when MeterRegistry bean is missing`() {
+        contextRunner
+            .run {
+                assertThat(it).doesNotHaveBean(MeterRegistry::class.java)
+                assertThat(it).doesNotHaveBean(MetricsPostProcessor::class.java)
+            }
+    }
+
+    @Test
+    fun `should register MetricsPostProcessor in context by default`() {
+        contextRunner
+            .withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration::class.java, CompositeMeterRegistryAutoConfiguration::class.java))
+            .run {
+                assertThat(it).hasSingleBean(MeterRegistry::class.java)
+                assertThat(it).hasSingleBean(MetricsPostProcessor::class.java)
+            }
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/retry/RetryableRecordHandlerAutoConfigurationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/retry/RetryableRecordHandlerAutoConfigurationTest.kt
@@ -1,0 +1,20 @@
+package de.bringmeister.spring.aws.kinesis.retry
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class RetryableRecordHandlerAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(RetryableRecordHandlerAutoConfiguration::class.java))
+
+    @Test
+    fun `should register RetryableRecordHandlerPostProcessor in context by default`() {
+        contextRunner
+            .run {
+                assertThat(it).hasSingleBean(RetryableRecordHandlerPostProcessor::class.java)
+            }
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/validation/KinesisValidationAutoConfigurationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/validation/KinesisValidationAutoConfigurationTest.kt
@@ -1,0 +1,54 @@
+package de.bringmeister.spring.aws.kinesis.validation
+
+import com.nhaarman.mockito_kotlin.mock
+import de.bringmeister.spring.aws.kinesis.metrics.MetricsPostProcessor
+import io.micrometer.core.instrument.MeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import javax.validation.Validator
+
+class KinesisValidationAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(KinesisValidationAutoConfiguration::class.java))
+
+    @Test
+    fun `should not register ValidatingPostProcessor when disabled`() {
+        contextRunner
+            .withUserConfiguration(MockValidatorConfiguration::class.java)
+            .withPropertyValues("aws.kinesis.validate: false")
+            .run {
+                assertThat(it).hasSingleBean(Validator::class.java)
+                assertThat(it).doesNotHaveBean(ValidatingPostProcessor::class.java)
+            }
+    }
+
+    @Test
+    fun `should not register ValidatingPostProcessor when Validator bean is missing`() {
+        contextRunner
+            .run {
+                assertThat(it).doesNotHaveBean(Validator::class.java)
+                assertThat(it).doesNotHaveBean(ValidatingPostProcessor::class.java)
+            }
+    }
+
+    @Test
+    fun `should register ValidatingPostProcessor in context by default`() {
+        contextRunner
+            .withUserConfiguration(MockValidatorConfiguration::class.java)
+            .run {
+                assertThat(it).hasSingleBean(Validator::class.java)
+                assertThat(it).hasSingleBean(ValidatingPostProcessor::class.java)
+            }
+    }
+
+    @TestConfiguration
+    private class MockValidatorConfiguration {
+        @Bean
+        fun validator() = mock<Validator>()
+    }
+}


### PR DESCRIPTION
Without this change the auto configuration was not picked up automatically.
It had to be imported to be enabled.