### PR TITLE
Add stream name, sequence number and partition key to MDC (OR-341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,29 @@ Default: `false`
 
 **Note**: This setting applies globally to the whole AWS SDK.
 
+
+#### MDC
+
+By default, this starter adds metadata when processing records to MDC.
+This feature can be disable by setting `mdc.enabled` flag to `false`:
+
+```yaml
+aws:
+  kinesis:
+    ...
+    mdc:
+      enabled: false
+```
+
+By default, `mdc.enabled` is turned on.
+
+Use the following properties to adjust the MDC property or disable it completely:
+* `aws.kinesis.mdc.stream-name-property`
+* `aws.kinesis.mdc.sequence-number-property`
+* `aws.kinesis.mdc.partition-key-property`
+
+Setting the property to `null` omits it from MDC. 
+
 #### Configuring initial position in stream
 
 You can use one of following values:

--- a/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/ContainerTest.kt
+++ b/src/integrationTest/kotlin/de/bringmeister/spring/aws/kinesis/ContainerTest.kt
@@ -1,6 +1,7 @@
 package de.bringmeister.spring.aws.kinesis
 
 import de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration
+import de.bringmeister.spring.aws.kinesis.mdc.KinesisMdcAutoConfiguration
 import de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration
 import de.bringmeister.spring.aws.kinesis.retry.RetryableRecordHandlerAutoConfiguration
 import de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration
@@ -17,7 +18,8 @@ import org.springframework.test.context.ActiveProfiles
         RetryableRecordHandlerAutoConfiguration::class,
         KinesisCreateStreamAutoConfiguration::class,
         KinesisMetricsAutoConfiguration::class,
-        KinesisValidationAutoConfiguration::class
+        KinesisValidationAutoConfiguration::class,
+        KinesisMdcAutoConfiguration::class
     ]
 )
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/KinesisMdcAutoConfiguration.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/KinesisMdcAutoConfiguration.kt
@@ -1,0 +1,18 @@
+package de.bringmeister.spring.aws.kinesis.mdc
+
+import de.bringmeister.spring.aws.kinesis.AwsKinesisAutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnProperty("aws.kinesis.mdc.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(MdcSettings::class)
+@AutoConfigureBefore(AwsKinesisAutoConfiguration::class)
+class KinesisMdcAutoConfiguration {
+
+    @Bean
+    fun mdcPostProcessor(settings: MdcSettings) = MdcPostProcessor(settings)
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcInboundHandler.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcInboundHandler.kt
@@ -1,0 +1,36 @@
+package de.bringmeister.spring.aws.kinesis.mdc
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.Record
+import org.slf4j.MDC
+
+class MdcInboundHandler<D, M>(
+    private val settings: MdcSettings,
+    private val delegate: KinesisInboundHandler<D, M>
+) : KinesisInboundHandler<D, M> by delegate {
+
+    override fun handleRecord(record: Record<D, M>, context: KinesisInboundHandler.ExecutionContext) {
+        try {
+            if (!settings.streamNameProperty.isNullOrBlank()) {
+                MDC.put(settings.streamNameProperty, stream)
+            }
+            if (!settings.sequenceNumberProperty.isNullOrBlank()) {
+                MDC.put(settings.sequenceNumberProperty, context.sequenceNumber)
+            }
+            if (!settings.partitionKeyProperty.isNullOrBlank()) {
+                MDC.put(settings.partitionKeyProperty, record.partitionKey)
+            }
+            delegate.handleRecord(record, context)
+        } finally {
+            if (!settings.streamNameProperty.isNullOrBlank()) {
+                MDC.remove(settings.streamNameProperty)
+            }
+            if (!settings.sequenceNumberProperty.isNullOrBlank()) {
+                MDC.remove(settings.sequenceNumberProperty)
+            }
+            if (!settings.partitionKeyProperty.isNullOrBlank()) {
+                MDC.remove(settings.partitionKeyProperty)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcPostProcessor.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcPostProcessor.kt
@@ -1,0 +1,16 @@
+package de.bringmeister.spring.aws.kinesis.mdc
+
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandlerPostProcessor
+import org.springframework.core.Ordered
+import javax.annotation.Priority
+
+@Priority(MdcPostProcessor.priority)
+class MdcPostProcessor(val settings: MdcSettings) : KinesisInboundHandlerPostProcessor {
+
+    companion object {
+        const val priority = Ordered.HIGHEST_PRECEDENCE + 1000
+    }
+
+    override fun postProcess(handler: KinesisInboundHandler<*, *>) = MdcInboundHandler(settings, handler)
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcSettings.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcSettings.kt
@@ -1,0 +1,13 @@
+package de.bringmeister.spring.aws.kinesis.mdc
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+@Validated
+@ConfigurationProperties(prefix = "aws.kinesis.mdc")
+class MdcSettings {
+
+    var streamNameProperty: String? = "awsStream"
+    var sequenceNumberProperty: String? = "awsSequenceNumber"
+    var partitionKeyProperty: String? = null
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ de.bringmeister.spring.aws.kinesis.KinesisLocalConfiguration, \
 de.bringmeister.spring.aws.kinesis.validation.KinesisValidationAutoConfiguration, \
 de.bringmeister.spring.aws.kinesis.creation.KinesisCreateStreamAutoConfiguration, \
 de.bringmeister.spring.aws.kinesis.metrics.KinesisMetricsAutoConfiguration, \
-de.bringmeister.spring.aws.kinesis.retry.RetryableRecordHandlerAutoConfiguration
+de.bringmeister.spring.aws.kinesis.retry.RetryableRecordHandlerAutoConfiguration, \
+de.bringmeister.spring.aws.kinesis.mdc.KinesisMdcAutoConfiguration

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/TestKinesisInboundHandler.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/TestKinesisInboundHandler.kt
@@ -7,7 +7,7 @@ internal class TestKinesisInboundHandler : KinesisInboundHandler<Any, Any> {
     override fun dataType() = Any::class.java
     override fun metaType() = Any::class.java
 
-    class TestExecutionContext : KinesisInboundHandler.ExecutionContext {
+    class TestExecutionContext(
         override val sequenceNumber: String = "any"
-    }
+    ) : KinesisInboundHandler.ExecutionContext
 }

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/mdc/KinesisMdcAutoConfigurationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/mdc/KinesisMdcAutoConfigurationTest.kt
@@ -1,0 +1,29 @@
+package de.bringmeister.spring.aws.kinesis.mdc
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class KinesisMdcAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(KinesisMdcAutoConfiguration::class.java))
+
+    @Test
+    fun `should not register MdcPostProcessor when disabled`() {
+        contextRunner
+            .withPropertyValues("aws.kinesis.mdc.enabled: false")
+            .run {
+                assertThat(it).doesNotHaveBean(MdcPostProcessor::class.java)
+            }
+    }
+
+    @Test
+    fun `should register MdcPostProcessor in context by default`() {
+        contextRunner
+            .run {
+                assertThat(it).hasSingleBean(MdcPostProcessor::class.java)
+            }
+    }
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcInboundHandlerTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcInboundHandlerTest.kt
@@ -1,0 +1,92 @@
+package de.bringmeister.spring.aws.kinesis.mdc
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
+import com.nhaarman.mockito_kotlin.whenever
+import de.bringmeister.spring.aws.kinesis.KinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.Record
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.Test
+import org.slf4j.MDC
+
+class MdcInboundHandlerTest {
+
+    private val mockDelegate = mock<KinesisInboundHandler<Any, Any>> { }
+
+    private val record = Record(Any(), Any())
+    private val context = TestKinesisInboundHandler.TestExecutionContext()
+
+    @Test
+    fun `should invoke delegate`() {
+        handler().handleRecord(record, context)
+        verify(mockDelegate).handleRecord(record, context)
+    }
+
+    @Test
+    fun `should add metadata to MDC`() {
+        val context = TestKinesisInboundHandler.TestExecutionContext(sequenceNumber = "some-sequence-number")
+        val settings = MdcSettings().apply {
+            streamNameProperty = "name"
+            sequenceNumberProperty = "sn"
+            partitionKeyProperty = "pk"
+        }
+
+        whenever(mockDelegate.handleRecord(record, context)).then {
+            assertThat(MDC.get(settings.streamNameProperty)).isEqualTo(mockDelegate.stream)
+            assertThat(MDC.get(settings.sequenceNumberProperty)).isEqualTo(context.sequenceNumber)
+            assertThat(MDC.get(settings.partitionKeyProperty)).isEqualTo(record.partitionKey)
+        }
+        handler(settings).handleRecord(record, context)
+
+        assertThat(MDC.getCopyOfContextMap()).isEmpty()
+    }
+
+    @Test
+    fun `should omit MDC when property is set to null`() {
+        val context = TestKinesisInboundHandler.TestExecutionContext(sequenceNumber = "omitted")
+        val settings = MdcSettings().apply {
+            streamNameProperty = null
+            sequenceNumberProperty = null
+            partitionKeyProperty = null
+        }
+
+        whenever(mockDelegate.handleRecord(record, context)).then {
+            assertThat(MDC.getCopyOfContextMap()).isEmpty()
+        }
+        handler(settings).handleRecord(record, context)
+
+        assertThat(MDC.getCopyOfContextMap()).isEmpty()
+    }
+
+    @Test
+    fun `should clear MDC when delegate throws`() {
+        val context = TestKinesisInboundHandler.TestExecutionContext(sequenceNumber = "cleared")
+
+        whenever(mockDelegate.handleRecord(record, context)).thenThrow(MyException)
+        val exception = catchThrowable { handler().handleRecord(record, context) }
+        assertThat(exception).isSameAs(MyException)
+
+        assertThat(MDC.getCopyOfContextMap()).isEmpty()
+    }
+
+    @Test
+    fun `should preserve existing MDC values`() {
+        val context = TestKinesisInboundHandler.TestExecutionContext(sequenceNumber = "cleared")
+
+        MDC.putCloseable("test", "some-value").use {
+            whenever(mockDelegate.handleRecord(record, context)).then {
+                assertThat(MDC.get("test")).isEqualTo("some-value")
+            }
+            handler().handleRecord(record, context)
+
+            assertThat(MDC.getCopyOfContextMap()).containsOnlyKeys("test")
+        }
+    }
+
+    private fun handler(settings: MdcSettings = MdcSettings()) = MdcInboundHandler(settings, mockDelegate)
+
+    private object MyException : IllegalStateException("expected")
+}

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcPostProcessorTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/mdc/MdcPostProcessorTest.kt
@@ -1,0 +1,25 @@
+package de.bringmeister.spring.aws.kinesis.mdc
+
+import com.nhaarman.mockito_kotlin.mock
+import de.bringmeister.spring.aws.kinesis.TestKinesisInboundHandler
+import de.bringmeister.spring.aws.kinesis.TestKinesisOutboundStream
+import de.bringmeister.spring.aws.kinesis.validation.ValidatingInboundHandler
+import de.bringmeister.spring.aws.kinesis.validation.ValidatingOutboundStream
+import de.bringmeister.spring.aws.kinesis.validation.ValidatingPostProcessor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import javax.validation.Validator
+
+class MdcPostProcessorTest {
+
+    private val processor = MdcPostProcessor(MdcSettings())
+
+    @Test
+    fun `should decorate handler with mdc wrapper`() {
+        val handler = TestKinesisInboundHandler()
+        val decorated = processor.postProcess(handler)
+
+        assertThat(decorated).isInstanceOf(MdcInboundHandler::class.java)
+        assertThat(decorated.stream).isSameAs(handler.stream)
+    }
+}


### PR DESCRIPTION
Add stream name, sequence number and partition key to MDC

Enabled by default for stream name and sequence number.
May be disabled by setting `aws.kinesis.mdc.enabled: false`.