### PR TITLE
Wait for Scheduler to shut down after graceful shutdown finished

### DIFF
--- a/src/integrationTest/resources/logback-spring.xml
+++ b/src/integrationTest/resources/logback-spring.xml
@@ -2,8 +2,8 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml" />
     <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
-    <!--<logger name="com.amazonaws.services.kinesis" level="DEBUG"/>-->
-    <logger name="de.bringmeister.spring.aws.kinesis" level="DEBUG"/>
+    <logger name="software.amazon" level="DEBUG"/>
+    <logger name="de.bringmeister.spring.aws.kinesis" level="TRACE"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE" />


### PR DESCRIPTION
Wait for Scheduler to shut down after graceful shutdown finished with `false`

KCL 2.x runs quite regularly into a race condition reporting incomplete shutdown.
Therefore, we're additionally waiting for the scheduler to successfully report
shutdown as per [the workaround mentioned in #542](https://github.com/awslabs/amazon-kinesis-client/issues/542).

@see https://github.com/awslabs/amazon-kinesis-client/issues/542
@see https://github.com/awslabs/amazon-kinesis-client/issues/616