### PR TITLE
Health indicator extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,16 @@ aws:
       disabled: true
 ```
 
+#### Enable health indicator
+If enabled it will extend actuator's health endpoint. 
+Only if all kinesis workers are ready with initialization, health status can be switched to UP.
+
+```yaml
+aws:
+  kinesis:
+    enableHealthIndicator: true
+```
+
 ## Usage
 
 ### Publishing messages

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettings.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettings.kt
@@ -5,7 +5,6 @@ import org.springframework.validation.annotation.Validated
 import software.amazon.kinesis.common.InitialPositionInStream
 import software.amazon.kinesis.metrics.MetricsLevel
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -57,6 +56,7 @@ class AwsKinesisSettings {
     var creationTimeout: Duration = Duration.ofSeconds(30)
     var streams: MutableList<StreamSettings> = mutableListOf()
     var roleCredentials: MutableList<RoleCredentials> = mutableListOf()
+    var enableHealthIndicator: Boolean = false
 
     fun getStreamSettingsOrDefault(stream: String): StreamSettings {
         return streams.firstOrNull { it.streamName == stream } ?: return defaultSettingsFor(stream)

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisListenerRegisterer.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisListenerRegisterer.kt
@@ -1,0 +1,21 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import de.bringmeister.spring.aws.kinesis.KinesisListenerProxyFactory
+import org.springframework.beans.factory.config.BeanPostProcessor
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("aws.kinesis.enableHealthIndicator", havingValue = "true")
+class KinesisListenerRegisterer(
+    private val kinesisListenerRegistry: KinesisListenerRegistry,
+    private val kinesisListenerProxyFactory: KinesisListenerProxyFactory
+) : BeanPostProcessor {
+
+    override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
+        kinesisListenerProxyFactory
+            .proxiesFor(bean)
+            .forEach { kinesisListenerRegistry.addStreamToCheckFor(it.stream) }
+        return bean
+    }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisListenerRegistry.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisListenerRegistry.kt
@@ -1,0 +1,48 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import de.bringmeister.spring.aws.kinesis.WorkerInitializedEvent
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+@ConditionalOnProperty("aws.kinesis.enableHealthIndicator", havingValue = "true")
+class KinesisListenerRegistry {
+
+    private val log: Logger = LoggerFactory.getLogger(this.javaClass)
+    private var latch: CountDownLatch? = null
+    private var streamCount = AtomicInteger(0)
+    private val streams = mutableMapOf<String, Boolean>()
+
+    @EventListener
+    internal fun workerInitializedEvent(workerInitializedEvent: WorkerInitializedEvent) {
+        if (latch == null) {
+            latch = CountDownLatch(streamCount.get())
+        }
+        val stream = workerInitializedEvent.streamName
+        if (streams[stream] == false) {
+            latch!!.countDown()
+            streams[stream] = true
+            log.info("Kinesis listener is initialized. [stream={}]", stream)
+        }
+    }
+
+    internal fun areAllListenersInitialized(): Boolean {
+        if (latch == null) {
+            latch = CountDownLatch(streamCount.get())
+        }
+        return latch!!.count <= 0
+    }
+
+    internal fun addStreamToCheckFor(stream: String) {
+        if (!streams.containsKey(stream)) {
+            log.info("Wait for Kinesis listener to be initialized. [stream={}]", stream)
+            streams[stream] = false
+            streamCount.incrementAndGet()
+        }
+    }
+}

--- a/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisListenersInitializationHealthIndicator.kt
+++ b/src/main/kotlin/de/bringmeister/spring/aws/kinesis/health/KinesisListenersInitializationHealthIndicator.kt
@@ -1,0 +1,20 @@
+package de.bringmeister.spring.aws.kinesis.health
+
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("aws.kinesis.enableHealthIndicator", havingValue = "true")
+class KinesisListenersInitializationHealthIndicator(
+    private val kinesisRegistry: KinesisListenerRegistry
+) : HealthIndicator {
+
+    override fun health(): Health {
+        val errorCode: Int = if (kinesisRegistry.areAllListenersInitialized()) 0 else 1
+        return if (errorCode != 0) {
+            Health.down().withDetail("Kinesis listeners are not initialized yet.", errorCode).build()
+        } else Health.up().build()
+    }
+}

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -124,6 +124,12 @@
       "name": "aws.kinesis.producer",
       "type": "java.util.List<de.bringmeister.spring.aws.kinesis.StreamSettings>",
       "sourceType": "de.bringmeister.spring.aws.kinesis.AwsKinesisSettings"
+    },
+    {
+      "name": "aws.kinesis.enableHealthIndicator",
+      "type": "java.lang.Boolean",
+      "sourceType": "de.bringmeister.spring.aws.kinesis.AwsKinesisSettings",
+      "defaultValue": false
     }
   ],
   "hints": [

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettingsTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/AwsKinesisSettingsTest.kt
@@ -10,12 +10,11 @@ import org.springframework.boot.context.properties.bind.BindException
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean
-import software.amazon.kinesis.common.InitialPositionInStream
 import java.time.Duration
 
 @RunWith(SpringRunner::class)
 @SpringBootTest(classes = [ValidationAutoConfiguration::class])
-class AwsKinesisProducerSettingsTest {
+class AwsKinesisSettingsTest {
 
     @Autowired
     private lateinit var localValidatorFactoryBean: LocalValidatorFactoryBean
@@ -140,5 +139,26 @@ class AwsKinesisProducerSettingsTest {
         assertThat(settings.kinesisUrl).isNull()
         assertThat(settings.dynamoDbSettings).isNull()
         assertThat(settings.createStreams).isTrue()
+    }
+
+    @Test
+    fun `should read configuration for health indicator creation`() {
+        val settings = builder<AwsKinesisSettings>()
+            .withPrefix("aws.kinesis")
+            .withProperty("region", "eu-central-1")
+            .withProperty("enableHealthIndicator", "true")
+            .validateUsing(localValidatorFactoryBean)
+            .build()
+        assertThat(settings.enableHealthIndicator).isTrue()
+    }
+
+    @Test
+    fun `should set default configuration for health indicator creation to false`() {
+        val settings = builder<AwsKinesisSettings>()
+            .withPrefix("aws.kinesis")
+            .withProperty("region", "eu-central-1")
+            .validateUsing(localValidatorFactoryBean)
+            .build()
+        assertThat(settings.enableHealthIndicator).isFalse()
     }
 }

--- a/src/test/kotlin/de/bringmeister/spring/aws/kinesis/HealthIndicatorPostProcessorIntegrationTest.kt
+++ b/src/test/kotlin/de/bringmeister/spring/aws/kinesis/HealthIndicatorPostProcessorIntegrationTest.kt
@@ -1,0 +1,52 @@
+package de.bringmeister.spring.aws.kinesis
+
+import com.nhaarman.mockito_kotlin.mock
+import de.bringmeister.spring.aws.kinesis.health.KinesisListenerRegisterer
+import de.bringmeister.spring.aws.kinesis.health.KinesisListenerRegistry
+import de.bringmeister.spring.aws.kinesis.health.KinesisListenersInitializationHealthIndicator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+
+class HealthIndicatorPostProcessorIntegrationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withInitializer(ConditionEvaluationReportLoggingListener())
+        .withUserConfiguration(HealthIndicatorTestConfiguration::class.java)
+        .withUserConfiguration(
+            KinesisListenerRegistry::class.java,
+            KinesisListenerRegisterer::class.java,
+            KinesisListenersInitializationHealthIndicator::class.java
+        )
+
+    @Test
+    fun `no health indicator should be created per default`() {
+        contextRunner
+            .run { context: AssertableApplicationContext? ->
+                assertThat(context).doesNotHaveBean(KinesisListenerRegistry::class.java)
+                assertThat(context).doesNotHaveBean(KinesisListenerRegisterer::class.java)
+                assertThat(context).doesNotHaveBean(KinesisListenersInitializationHealthIndicator::class.java)
+            }
+    }
+
+    @Test
+    fun `health indicator should be created if configured`() {
+        contextRunner
+            .withPropertyValues("aws.kinesis.enableHealthIndicator=true")
+            .run { context: AssertableApplicationContext? ->
+                assertThat(context).hasSingleBean(KinesisListenerRegistry::class.java)
+                assertThat(context).hasSingleBean(KinesisListenerRegisterer::class.java)
+                assertThat(context).hasSingleBean(KinesisListenersInitializationHealthIndicator::class.java)
+            }
+    }
+
+    @TestConfiguration
+    internal class HealthIndicatorTestConfiguration {
+        @Bean
+        fun kinesisListenerProxyFactory() = mock<KinesisListenerProxyFactory> { }
+    }
+}


### PR DESCRIPTION
Configurable extension: if enabled, then /actuator/health is set to UP only after kinesis listeners are finished with initializing.
Per default is set to false.